### PR TITLE
Fix CodeQL ReDoS findings and add repository guardrails

### DIFF
--- a/.github/workflows/ContinuousIntegration.yml
+++ b/.github/workflows/ContinuousIntegration.yml
@@ -3,7 +3,7 @@ name: Continuous integration
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [master]
 
 permissions:
   contents: read

--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -5,7 +5,7 @@ name: Discovery
 
 on:
   push:
-    branches: [main]
+    branches: [master]
     paths:
       - "llms.txt"
       - "llms-full.txt"

--- a/coding.rules.md
+++ b/coding.rules.md
@@ -1,0 +1,63 @@
+# Agent Safe Pipeline Coding Rules
+
+These rules apply to the `agent-safe-pipeline` workspace. They are release requirements alongside
+`security.rules.md` and `discovery.rules.md`.
+
+## 1. Structure and naming
+
+- Production TypeScript belongs under `packages/pipeline/src/`; tests belong under the sibling
+  `packages/pipeline/test/` tree and should mirror the source feature when useful.
+- Group code by responsibility: `intent`, `decision`, `approval`, `execution`, `shadow`, and
+  narrowly scoped supporting modules such as `http`.
+- Use PascalCase for TypeScript file names, classes, interfaces, and exported types. Use camelCase
+  for variables, properties, and methods.
+- Keep the public surface explicit through `packages/pipeline/src/Index.ts`. Internal helpers must
+  not become exports accidentally.
+- Keep each class or module focused on one trust-boundary responsibility. Extract shared behavior
+  instead of duplicating security-sensitive validation.
+
+## 2. Architecture
+
+- Preserve the separation between intent capture, independent decision authority, optional human
+  approval, authorization verification, and action execution.
+- An agent may propose an action but must never authorize its own execution.
+- Keep captured intents and decisions immutable. Any transformation that affects authorization
+  must be represented in the canonical intent hash.
+- Depend on interfaces at boundaries (`DecisionAuthority`, `AuthorizationVerifier`, action
+  handlers, replay storage) so production integrations remain replaceable and testable.
+- Do not add hidden network calls, ambient credentials, or implicit execution to constructors or
+  data-model helpers.
+
+## 3. TypeScript and readability
+
+- Maintain strict TypeScript settings and ESM/NodeNext imports, including `.js` extensions for
+  relative runtime imports.
+- Prefer precise domain types over `any`, unchecked casts, or stringly typed state.
+- Use stable, non-sensitive error/reason codes at trust boundaries. Do not expose raw downstream
+  errors, credentials, tokens, or response bodies.
+- Bound all input-dependent work. Avoid ambiguous or backtracking regular expressions on caller-
+  controlled data; use linear scans or platform parsers where possible.
+- Comments should explain invariants and security reasoning, not restate syntax.
+
+## 4. Change discipline
+
+- Preserve fail-closed behavior. Network, parsing, verification, replay-store, and binding
+  uncertainty must not produce an executable authorization.
+- Add a regression test for every bug fix. Security and performance fixes require an adversarial
+  case that would have triggered the original failure mode.
+- Keep refactors behavior-preserving and separate from feature changes where practical.
+- Update examples and the package README when a public API, required environment variable, or
+  outcome contract changes.
+
+## 5. Required validation
+
+- `pnpm format`
+- `pnpm lint`
+- `pnpm security`
+- `pnpm performance`
+- `pnpm typecheck`
+- `pnpm test`
+- `pnpm build`
+
+Run `pnpm verify` before opening or updating a pull request. Do not weaken checks, coverage, or
+strict compiler options to make a change pass.

--- a/discovery.rules.md
+++ b/discovery.rules.md
@@ -1,0 +1,74 @@
+# Agent Safe Pipeline Discovery Rules
+
+These rules keep `agent-safe-pipeline` discoverable by developers, search systems, and AI agents
+without overstating what the package ships. They apply alongside `coding.rules.md` and
+`security.rules.md`.
+
+## 1. Verify before claiming
+
+- Describe the package as an execution architecture in which agents may propose actions but cannot
+  authorize their own execution. Do not claim that the package alone secures an entire agent,
+  deployment, or downstream system.
+- Capability claims must match shipped code and tests. Distinguish reference adapters and examples
+  from production services operated by Decionis.
+- Never publish registry, marketplace, documentation, or repository links before verifying that the
+  destination resolves publicly.
+- Do not publish latency, throughput, accuracy, or security-effectiveness numbers without a checked-
+  in benchmark or governed measurement that pins the claim.
+- Use absolute public links in npm-facing documentation and machine-readable discovery files.
+
+## 2. Canonical discovery surfaces
+
+- `README.md` is the human entry point and must explain the trust boundary, install path, minimal
+  usage, ALLOW/HOLD/BLOCK behavior, support, and license.
+- `packages/pipeline/README.md` is the package-facing source that ships to npm. It must not link to
+  repository-relative files that are absent from the published tarball.
+- `llms.txt` is the concise package and documentation map. `llms-full.txt` is its detailed superset;
+  both must use the same frozen product vocabulary.
+- `package.json` metadata, exports, files, engine requirements, and repository links must match the
+  actual published artifact.
+- Do not add OpenAPI, MCP, security.txt, sitemap, or registry manifests unless the corresponding
+  callable surface actually exists in this repository.
+
+## 3. Drift prevention
+
+- `scripts/CheckDiscovery.mjs` must validate the discovery files and their public links. Extend this
+  check whenever a new hand-maintained inventory or discovery surface is added.
+- Every exported API named in discovery copy must exist in `packages/pipeline/src/Index.ts` and be
+  covered by build/type checks.
+- Examples may demonstrate only public exports and documented environment variables. An example is
+  not evidence that a hosted integration exists.
+- Remove stale claims and links in the same pull request that removes or renames the underlying
+  capability.
+
+## 4. Package release rules
+
+- The npm README must contain a one-line description, install command, minimal end-to-end example,
+  fail-closed/outcome semantics, support information, and license.
+- Verify the npm package page and any other distribution URL on the release date before adding it to
+  `sameAs`, package inventories, or discovery copy.
+- Regenerate and inspect the package tarball before release. Only `dist`, `README.md`, and `LICENSE`
+  should ship unless the manifest intentionally says otherwise.
+- Documentation improvements do not reach npm until a new package version is published; include
+  them in the release plan.
+
+## 5. Pull-request checklist
+
+- [ ] Claims match shipped public exports and tested behavior
+- [ ] `README.md`, package README, `llms.txt`, and `llms-full.txt` remain consistent
+- [ ] All external URLs resolve and all off-repo links are absolute
+- [ ] No unsupported performance, security, or availability figures were introduced
+- [ ] `pnpm discovery` and `pnpm verify` pass
+- [ ] Public API or package changes include an inspected package build/tarball
+
+## 6. Current validation entry points
+
+| Concern                  | Agent Safe Pipeline source       |
+| ------------------------ | -------------------------------- |
+| Public exports           | `packages/pipeline/src/Index.ts` |
+| Human documentation      | `README.md`                      |
+| npm documentation        | `packages/pipeline/README.md`    |
+| Machine-readable summary | `llms.txt`                       |
+| Detailed agent context   | `llms-full.txt`                  |
+| Discovery drift gate     | `scripts/CheckDiscovery.mjs`     |
+| Package metadata         | `packages/pipeline/package.json` |

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,11 +1,14 @@
 import eslint from "@eslint/js";
 import tseslint from "@typescript-eslint/eslint-plugin";
 import parser from "@typescript-eslint/parser";
+import regexp from "eslint-plugin-regexp";
 import globals from "globals";
 
 export default [
   { ignores: ["**/dist/**", "**/coverage/**", "**/node_modules/**"] },
   eslint.configs.recommended,
+  regexp.configs["flat/recommended"],
+  { rules: { "regexp/no-super-linear-move": ["error", { report: "potential" }] } },
   {
     files: ["**/*.ts"],
     languageOptions: {

--- a/package.json
+++ b/package.json
@@ -19,9 +19,16 @@
     "format": "prettier --check .",
     "format:fix": "prettier --write .",
     "lint": "eslint .",
+    "performance": "pnpm --filter @decionis/agent-safe-pipeline test:performance",
+    "precommit": "pnpm lint && pnpm security && pnpm performance",
+    "prepare": "simple-git-hooks",
+    "security": "pnpm audit --audit-level moderate",
     "test": "pnpm -r test",
     "typecheck": "pnpm --filter @decionis/agent-safe-pipeline build && pnpm -r typecheck",
-    "verify": "pnpm format && pnpm lint && pnpm discovery && pnpm typecheck && pnpm test && pnpm build"
+    "verify": "pnpm format && pnpm lint && pnpm security && pnpm discovery && pnpm typecheck && pnpm test && pnpm build"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "pnpm precommit"
   },
   "devDependencies": {
     "@eslint/js": "^9.16.0",
@@ -31,8 +38,10 @@
     "eslint": "^9.16.0",
     "eslint-import-resolver-typescript": "^4.3.5",
     "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-regexp": "^2.10.0",
     "globals": "^15.14.0",
     "prettier": "^3.2.5",
+    "simple-git-hooks": "^2.13.1",
     "typescript": "^5.6.3"
   }
 }

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "test": "vitest run --coverage",
+    "test:performance": "vitest run test/performance",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {

--- a/packages/pipeline/src/decision/DecionisGate.ts
+++ b/packages/pipeline/src/decision/DecionisGate.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AuthorityBaseUrl } from "../http/AuthorityBaseUrl.js";
 import { CanonicalIntentHasher } from "../intent/CanonicalIntentHasher.js";
 import type { CapturedIntent } from "../intent/ExecutionIntent.js";
 import {
@@ -36,14 +37,10 @@ export class DecionisGate implements DecisionAuthority {
   private readonly fetchImpl: typeof fetch;
 
   public constructor(options: DecionisGateOptions) {
-    const url = new URL(options.baseUrl);
-    const loopback =
-      url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
-    if (url.username || url.password) throw new Error("DECIONIS_URL_MUST_NOT_CONTAIN_CREDENTIALS");
-    if (url.protocol !== "https:" && !(options.allowInsecureLoopback === true && loopback)) {
-      throw new Error("DECIONIS_URL_MUST_USE_HTTPS");
-    }
-    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.baseUrl = AuthorityBaseUrl.normalize(
+      options.baseUrl,
+      options.allowInsecureLoopback === true,
+    );
     this.apiKey = options.apiKey;
     this.timeoutMs = Math.min(Math.max(options.timeoutMs ?? 4_000, 1), 15_000);
     this.fetchImpl = options.fetch ?? fetch;

--- a/packages/pipeline/src/execution/AuthorizationVerifier.ts
+++ b/packages/pipeline/src/execution/AuthorizationVerifier.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { AuthorityBaseUrl } from "../http/AuthorityBaseUrl.js";
 import { CanonicalIntentHasher } from "../intent/CanonicalIntentHasher.js";
 import type { CapturedIntent } from "../intent/ExecutionIntent.js";
 import type { GateDecision } from "../decision/DecisionAuthority.js";
@@ -44,14 +45,10 @@ export class DecionisGrantVerifier implements AuthorizationVerifier {
   private readonly fetchImpl: typeof fetch;
 
   public constructor(options: DecionisGrantVerifierOptions) {
-    const url = new URL(options.baseUrl);
-    const loopback =
-      url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
-    if (url.username || url.password) throw new Error("DECIONIS_URL_MUST_NOT_CONTAIN_CREDENTIALS");
-    if (url.protocol !== "https:" && !(options.allowInsecureLoopback === true && loopback)) {
-      throw new Error("DECIONIS_URL_MUST_USE_HTTPS");
-    }
-    this.baseUrl = options.baseUrl.replace(/\/+$/, "");
+    this.baseUrl = AuthorityBaseUrl.normalize(
+      options.baseUrl,
+      options.allowInsecureLoopback === true,
+    );
     this.apiKey = options.apiKey;
     this.timeoutMs = Math.min(Math.max(options.timeoutMs ?? 4_000, 1), 15_000);
     this.fetchImpl = options.fetch ?? fetch;

--- a/packages/pipeline/src/http/AuthorityBaseUrl.ts
+++ b/packages/pipeline/src/http/AuthorityBaseUrl.ts
@@ -1,0 +1,20 @@
+export class AuthorityBaseUrl {
+  public static normalize(value: string, allowInsecureLoopback = false): string {
+    const url = new URL(value);
+    const loopback =
+      url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]";
+
+    if (url.username || url.password) {
+      throw new Error("DECIONIS_URL_MUST_NOT_CONTAIN_CREDENTIALS");
+    }
+    if (url.protocol !== "https:" && !(allowInsecureLoopback && loopback)) {
+      throw new Error("DECIONIS_URL_MUST_USE_HTTPS");
+    }
+
+    let end = value.length;
+    while (end > 0 && value.charCodeAt(end - 1) === 47) {
+      end -= 1;
+    }
+    return value.slice(0, end);
+  }
+}

--- a/packages/pipeline/test/http/AuthorityBaseUrl.test.ts
+++ b/packages/pipeline/test/http/AuthorityBaseUrl.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { AuthorityBaseUrl } from "../../src/http/AuthorityBaseUrl.js";
+
+describe("AuthorityBaseUrl", () => {
+  it("removes trailing path separators without changing internal path separators", () => {
+    expect(AuthorityBaseUrl.normalize("https://authority.example/v1////")).toBe(
+      "https://authority.example/v1",
+    );
+    expect(AuthorityBaseUrl.normalize("https://authority.example//v1")).toBe(
+      "https://authority.example//v1",
+    );
+  });
+
+  it("allows insecure transport only for explicitly enabled loopback URLs", () => {
+    expect(AuthorityBaseUrl.normalize("http://localhost:3001/", true)).toBe(
+      "http://localhost:3001",
+    );
+    expect(() => AuthorityBaseUrl.normalize("http://authority.example")).toThrow(
+      "DECIONIS_URL_MUST_USE_HTTPS",
+    );
+  });
+
+  it("rejects credentials embedded in authority URLs", () => {
+    expect(() => AuthorityBaseUrl.normalize("https://user:secret@authority.example")).toThrow(
+      "DECIONIS_URL_MUST_NOT_CONTAIN_CREDENTIALS",
+    );
+  });
+});

--- a/packages/pipeline/test/performance/AuthorityBaseUrlPerformance.test.ts
+++ b/packages/pipeline/test/performance/AuthorityBaseUrlPerformance.test.ts
@@ -1,0 +1,15 @@
+import { performance } from "node:perf_hooks";
+import { describe, expect, it } from "vitest";
+import { AuthorityBaseUrl } from "../../src/http/AuthorityBaseUrl.js";
+
+describe("AuthorityBaseUrl performance", () => {
+  it("normalizes an adversarial slash run within the performance budget", () => {
+    const baseUrl = `https://authority.example/${"/".repeat(100_000)}sentinel`;
+    const startedAt = performance.now();
+
+    const normalized = AuthorityBaseUrl.normalize(baseUrl);
+
+    expect(normalized).toBe(baseUrl);
+    expect(performance.now() - startedAt).toBeLessThan(1_000);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,12 +32,18 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5)(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5)
+      eslint-plugin-regexp:
+        specifier: ^2.10.0
+        version: 2.10.0(eslint@9.39.5)
       globals:
         specifier: ^15.14.0
         version: 15.15.0
       prettier:
         specifier: ^3.2.5
         version: 3.9.6
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       typescript:
         specifier: ^5.6.3
         version: 5.9.3
@@ -918,6 +924,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  comment-parser@1.4.8:
+    resolution: {integrity: sha512-rKZTGo4fzKYna8UcL0isTg5wkBNla7bxTypLwZQXjIdi++IdP1OJ41rI5Mti3/jltkPujbu4i9LIARYA+zpotQ==}
+    engines: {node: '>= 12.0.0'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1123,6 +1133,12 @@ packages:
     peerDependenciesMeta:
       '@typescript-eslint/parser':
         optional: true
+
+  eslint-plugin-regexp@2.10.0:
+    resolution: {integrity: sha512-ovzQT8ESVn5oOe5a7gIDPD5v9bCSjIFJu57sVPDqgPRXicQzOnYfFN21WoQBQF18vrhT5o7UMKFwJQVVjyJ0ng==}
+    engines: {node: ^18 || >=20}
+    peerDependencies:
+      eslint: '>=8.44.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -1538,6 +1554,10 @@ packages:
     resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
+  jsdoc-type-pratt-parser@4.8.0:
+    resolution: {integrity: sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==}
+    engines: {node: '>=12.0.0'}
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1788,9 +1808,17 @@ packages:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
 
+  refa@0.12.1:
+    resolution: {integrity: sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
+
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regexp-ast-analysis@0.7.1:
+    resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
+    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -1835,6 +1863,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  scslre@0.3.0:
+    resolution: {integrity: sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==}
+    engines: {node: ^14.0.0 || >=16.0.0}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -1898,6 +1930,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2937,6 +2973,8 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  comment-parser@1.4.8: {}
+
   concat-map@0.0.1: {}
 
   content-disposition@1.1.0: {}
@@ -3220,6 +3258,17 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-regexp@2.10.0(eslint@9.39.5):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.10.1(eslint@9.39.5)
+      '@eslint-community/regexpp': 4.12.2
+      comment-parser: 1.4.8
+      eslint: 9.39.5
+      jsdoc-type-pratt-parser: 4.8.0
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
+      scslre: 0.3.0
 
   eslint-scope@8.4.0:
     dependencies:
@@ -3691,6 +3740,8 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdoc-type-pratt-parser@4.8.0: {}
+
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
@@ -3921,6 +3972,10 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
+  refa@0.12.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+
   reflect.getprototypeof@1.0.10:
     dependencies:
       call-bind: 1.0.9
@@ -3931,6 +3986,11 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regexp-ast-analysis@0.7.1:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
 
   regexp.prototype.flags@1.5.4:
     dependencies:
@@ -4018,6 +4078,12 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  scslre@0.3.0:
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      refa: 0.12.1
+      regexp-ast-analysis: 0.7.1
 
   semver@6.3.1: {}
 
@@ -4109,6 +4175,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   source-map-js@1.2.1: {}
 

--- a/security.rules.md
+++ b/security.rules.md
@@ -1,0 +1,100 @@
+# Agent Safe Pipeline Security and Performance Rules
+
+These rules apply to the `agent-safe-pipeline` workspace. They are release requirements and do not
+authorize testing production, customer, marketplace, or third-party systems. Security and load tests
+must use local injection, loopback, mocks, or an explicitly authorized isolated environment.
+
+## 1. Trust-boundary invariants
+
+- An agent may capture and submit intent but must never mint, approve, verify, or consume its own
+  execution authorization.
+- Intent capture, independent decision, optional presence approval, grant verification, replay
+  prevention, and execution remain separate stages with explicit interfaces.
+- Every executable decision must bind the canonical intent hash, decision ID, dossier ID, grant ID,
+  and expiry. Missing or mismatched binding fails closed.
+- Captured intents, decisions, and authorization evidence are immutable after creation.
+- `ALLOW` without a valid, unexpired, atomically consumable grant is not executable.
+
+## 2. Network and input safety
+
+- Authority and verification endpoints require HTTPS. Plain HTTP is permitted only for explicit
+  loopback use in local development or tests.
+- URLs containing credentials are forbidden. API keys and bearer tokens must be supplied through
+  headers and must never appear in URLs, logs, errors, or persisted evidence.
+- Downstream timeouts must be finite and clamped to the documented maximum. Abort timers must always
+  be cleared.
+- Authority responses are capped at 100 KiB before JSON parsing. Malformed, oversized, or schema-
+  invalid responses fail closed without exposing their contents.
+- Caller-controlled work must be bounded and linear where practical. Ambiguous backtracking regular
+  expressions on URLs, identifiers, tokens, or response text are prohibited.
+- Use strict schemas for external data and reject unknown execution semantics rather than guessing.
+
+## 3. Authorization, replay, and execution
+
+- Canonical hashing must cover action, target, parameters, tenant, actor, downstream operation,
+  idempotency key, and security-relevant context in stable order.
+- Grant verification must compare the consumed grant to the captured intent and independent decision
+  before returning `VerifiedAuthorization`.
+- Replay storage must use single-winner semantics. A store error or duplicate grant must block
+  execution.
+- The action registry is an allowlist. Never resolve arbitrary modules, shell commands, URLs, or
+  functions directly from agent-controlled action names.
+- The executor must re-check intent conformance immediately before invoking the registered handler.
+- Logs and telemetry may contain stable IDs and hashes; they must not contain raw API keys, bearer
+  tokens, authorization headers, sensitive parameters, or downstream response bodies.
+
+## 4. Dependency and source security
+
+- Use the declared pnpm version and commit `pnpm-lock.yaml`. CI and release installs use
+  `--frozen-lockfile`.
+- `pnpm audit --audit-level moderate` must pass before commit and in CI. Critical/high findings block
+  merge; lower findings require triage and a documented disposition.
+- GitHub Actions must be pinned to immutable commit SHAs and use least-privilege permissions.
+- CodeQL high/critical findings block merge. Fix the data flow and add a regression test; do not
+  dismiss a true positive or suppress a rule to obtain a green check.
+- Regular expressions are linted for exponential or polynomial backtracking. Security rules must not
+  be disabled inline without maintainer review and a bounded-input proof.
+
+## 5. Performance requirements
+
+- Security-sensitive parsing, normalization, hashing, replay checks, and registry lookup must have
+  bounded complexity under adversarial input.
+- Performance regressions require a deterministic local test with a generous budget and an input
+  shaped like the original worst case.
+- Do not use production endpoints for load or performance checks. Network behavior must be mocked or
+  limited to loopback.
+- A performance test may use a wall-clock ceiling only when the gap between safe and vulnerable
+  behavior is large enough to avoid flaky results.
+
+## 6. Required tests
+
+- Binding tests cover intent, decision, dossier, grant, and expiry mismatch.
+- Replay tests cover duplicate and concurrent consumption with at most one successful execution.
+- URL tests cover HTTPS, explicit loopback HTTP, embedded credentials, trailing separators, and
+  adversarial separator runs.
+- Response tests cover transport failure, non-success status, malformed JSON, oversized bodies, and
+  schema mismatch.
+- Executor tests cover unknown actions, conformance failure, missing authorization, handler failure,
+  and successful single execution.
+
+## 7. Release checklist
+
+- [ ] `pnpm install --frozen-lockfile` succeeds
+- [ ] `pnpm audit --audit-level moderate` reports no blocking findings
+- [ ] `pnpm verify` passes, including security and performance checks
+- [ ] CodeQL has no unresolved high/critical findings introduced by the change
+- [ ] No secret, token, credential, private URL, or sensitive fixture is present in the diff
+- [ ] Public exports, examples, package README, and discovery files match shipped behavior
+
+## 8. Current validation entry points
+
+| Concern                   | Agent Safe Pipeline source                                 |
+| ------------------------- | ---------------------------------------------------------- |
+| Canonical intent binding  | `packages/pipeline/src/intent/CanonicalIntentHasher.ts`    |
+| Independent authority     | `packages/pipeline/src/decision/DecionisGate.ts`           |
+| Grant consumption         | `packages/pipeline/src/execution/AuthorizationVerifier.ts` |
+| Replay prevention         | `packages/pipeline/src/execution/ReplayStore.ts`           |
+| Execution boundary        | `packages/pipeline/src/execution/SafeExecutor.ts`          |
+| URL hardening             | `packages/pipeline/src/http/AuthorityBaseUrl.ts`           |
+| Security regression tests | `packages/pipeline/test/`                                  |
+| Performance regressions   | `packages/pipeline/test/performance/`                      |


### PR DESCRIPTION
## Summary

- replace both CodeQL-flagged trailing-slash regular expressions with a shared linear-time URL normalizer
- add functional coverage and an adversarial 100,000-character performance regression
- add regex-specific ESLint rules for super-linear backtracking and movement
- install a pre-commit hook that runs lint, dependency security, and performance checks
- copy and tailor the Decionis coding, discovery, and security rules for Agent Safe Pipeline
- update workflow push triggers for the renamed `master` default branch

## Root cause

`DecionisGate` and `DecionisGrantVerifier` both normalized caller-controlled authority URLs with `/\/+$/`. On a long run of slashes followed by a non-slash character, the unanchored starting position and greedy quantifier can produce polynomial work in the JavaScript regular-expression engine.

The new `AuthorityBaseUrl` parser validates the existing URL invariants and removes trailing separators with a single bounded scan, eliminating the vulnerable regex from both paths.

## Security and repository impact

- `pnpm security` rejects moderate-or-higher dependency advisories
- `pnpm performance` runs the adversarial URL normalization budget
- `pnpm precommit` runs lint, security, and performance checks through `simple-git-hooks`
- repository administration was updated separately: the default branch is now `master`, and branch protection requires PRs plus `verify` and both CodeQL analysis checks; force pushes and deletion are disabled

## Validation

- `pnpm precommit`
- `pnpm verify`
- 10 test files and 28 tests passing
- 96.9% statement coverage
- no known dependency vulnerabilities
- adversarial URL normalization completes in approximately 2–4 ms locally against a 1,000 ms budget

Addresses code-scanning alerts 1 and 2.
