### PR TITLE
Automate verified GitHub releases

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: agent-safe-ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: agent-safe-ci-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   verify:
@@ -49,3 +49,74 @@ jobs:
           path: packages/pipeline/coverage/
           if-no-files-found: warn
           retention-days: 14
+
+  release:
+    name: Release
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: verify
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Resolve release version
+        id: release
+        shell: bash
+        run: |
+          set -euo pipefail
+          workspace_version="$(node -p "require('./package.json').version")"
+          package_version="$(node -p "require('./packages/pipeline/package.json').version")"
+
+          if [[ "$workspace_version" != "$package_version" ]]; then
+            echo "Workspace and package versions must match." >&2
+            exit 1
+          fi
+
+          semver='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$package_version" =~ $semver ]]; then
+            echo "Package version is not valid semantic versioning: $package_version" >&2
+            exit 1
+          fi
+
+          echo "version=$package_version" >> "$GITHUB_OUTPUT"
+          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
+      - name: Create GitHub release
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+          TARGET_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Release $RELEASE_TAG already exists; nothing to create."
+            exit 0
+          fi
+
+          if gh api "repos/$GH_REPO/git/ref/tags/$RELEASE_TAG" >/dev/null 2>&1; then
+            echo "Tag $RELEASE_TAG exists without a GitHub release; refusing to reuse it." >&2
+            exit 1
+          fi
+
+          release_args=(
+            "$RELEASE_TAG"
+            --target "$TARGET_SHA"
+            --title "$RELEASE_TAG"
+            --generate-notes
+          )
+          if [[ "$RELEASE_VERSION" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "${release_args[@]}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
       - name: Resolve release version
         id: release
         shell: bash
@@ -74,9 +78,15 @@ jobs:
           set -euo pipefail
           workspace_version="$(node -p "require('./package.json').version")"
           package_version="$(node -p "require('./packages/pipeline/package.json').version")"
+          package_name="$(node -p "require('./packages/pipeline/package.json').name")"
 
           if [[ "$workspace_version" != "$package_version" ]]; then
             echo "Workspace and package versions must match." >&2
+            exit 1
+          fi
+
+          if [[ "$package_name" != "@decionis/agent-safe-pipeline" ]]; then
+            echo "Unexpected release package: $package_name" >&2
             exit 1
           fi
 
@@ -86,12 +96,16 @@ jobs:
             exit 1
           fi
 
-          echo "version=$package_version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$package_version" >> "$GITHUB_OUTPUT"
+          {
+            echo "package=$package_name"
+            echo "version=$package_version"
+            echo "tag=v$package_version"
+          } >> "$GITHUB_OUTPUT"
       - name: Create GitHub release
         env:
           GH_REPO: ${{ github.repository }}
           GH_TOKEN: ${{ github.token }}
+          NPM_PACKAGE: ${{ steps.release.outputs.package }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}
           RELEASE_VERSION: ${{ steps.release.outputs.version }}
           TARGET_SHA: ${{ github.sha }}
@@ -115,6 +129,15 @@ jobs:
             --title "$RELEASE_TAG"
             --generate-notes
           )
+
+          published_version="$(npm view "$NPM_PACKAGE@$RELEASE_VERSION" version 2>/dev/null || true)"
+          if [[ "$published_version" == "$RELEASE_VERSION" ]]; then
+            npm_url="https://www.npmjs.com/package/$NPM_PACKAGE/v/$RELEASE_VERSION"
+            release_args+=(--notes "npm package: [$NPM_PACKAGE@$RELEASE_VERSION]($npm_url)")
+          else
+            echo "No matching public npm publication found; creating a GitHub-only release."
+          fi
+
           if [[ "$RELEASE_VERSION" == *-* ]]; then
             release_args+=(--prerelease)
           fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,4 +19,4 @@ Contributions are licensed under Apache-2.0. By submitting a contribution, you r
 
 After verification succeeds on a merge to `master`, CI reads the matching workspace and package versions and creates the corresponding `v<version>` GitHub release. Existing releases are skipped safely, prerelease versions are marked as prereleases, and a tag without a matching GitHub release fails closed for manual review. Increment both versions in the release PR when a new release is intended.
 
-This workflow creates a GitHub release only. Publishing `@decionis/agent-safe-pipeline` to npm remains a separate, explicitly authorized operation.
+If the exact `@decionis/agent-safe-pipeline` version is already public on npm when the job runs, its registry link is prepended to the GitHub release notes. The workflow does not publish to npm; publishing remains a separate, explicitly authorized operation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,3 +14,9 @@ Security-boundary changes must include negative tests and document their fail-op
 Do not add secrets, production policy data, customer fixtures, generated dependency directories, or claims that an endpoint/package is live without verifying it. Use synthetic identifiers and values in examples.
 
 Contributions are licensed under Apache-2.0. By submitting a contribution, you represent that you have the right to license it on those terms.
+
+## Releases
+
+After verification succeeds on a merge to `master`, CI reads the matching workspace and package versions and creates the corresponding `v<version>` GitHub release. Existing releases are skipped safely, prerelease versions are marked as prereleases, and a tag without a matching GitHub release fails closed for manual review. Increment both versions in the release PR when a new release is intended.
+
+This workflow creates a GitHub release only. Publishing `@decionis/agent-safe-pipeline` to npm remains a separate, explicitly authorized operation.

--- a/scripts/CheckLicenses.mjs
+++ b/scripts/CheckLicenses.mjs
@@ -26,6 +26,26 @@ if (unsupported.length > 0) {
   throw new Error(`Unreviewed workspace dependency licenses: ${unsupported.join(", ")}`);
 }
 
+const repositoryLicense = await readFile("LICENSE", "utf8");
+const packageLicense = await readFile("packages/pipeline/LICENSE", "utf8");
+const apacheLicenseMarkers = [
+  "Apache License",
+  "Version 2.0, January 2004",
+  "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION",
+  "END OF TERMS AND CONDITIONS",
+  'Licensed under the Apache License, Version 2.0 (the "License")',
+];
+
+for (const marker of apacheLicenseMarkers) {
+  if (!repositoryLicense.includes(marker)) {
+    throw new Error(`LICENSE is not the complete Apache-2.0 license: missing ${marker}`);
+  }
+}
+
+if (packageLicense !== repositoryLicense) {
+  throw new Error("packages/pipeline/LICENSE must match the repository Apache-2.0 license");
+}
+
 const exampleManifests = (await readdir("examples", { withFileTypes: true }))
   .filter((entry) => entry.isDirectory())
   .map((entry) => `examples/${entry.name}/package.json`);
@@ -35,6 +55,13 @@ for (const path of manifests) {
   const manifest = JSON.parse(await readFile(path, "utf8"));
   if (manifest.license !== "Apache-2.0") {
     throw new Error(`${path} must declare Apache-2.0`);
+  }
+
+  if (
+    path === "packages/pipeline/package.json" &&
+    (!Array.isArray(manifest.files) || !manifest.files.includes("LICENSE"))
+  ) {
+    throw new Error("packages/pipeline/package.json must include LICENSE in published files");
   }
 }
 


### PR DESCRIPTION
## What changed

- add a release job after CI verification on pushes to master
- derive v<version> from matching workspace and package versions
- safely skip an existing release and fail on an orphaned tag
- mark semantic prerelease versions as GitHub prereleases
- link the exact public npm publication in release notes when one already exists
- strengthen Apache-2.0 checks for repository and distributed package license files
- document the GitHub-only release process

## Why

Releases were manual, and the license check covered manifest metadata but not the actual license text copied into the published package.

## Impact

Merging a version bump to master now creates a GitHub release only after verification succeeds. The workflow does not publish to npm. If the exact package version is already public on npm, the generated release notes include its registry link. The existing v0.1.0 release is idempotently skipped until both manifests are incremented.

## Validation

- pnpm verify: 28 tests pass and coverage thresholds are satisfied
- actionlint
- Gitleaks directory scan
- npm package dry run confirms LICENSE inclusion
- GitHub recognizes the repository license as Apache-2.0