### PR TITLE
Fix Linux license inventory CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,10 +37,11 @@ jobs:
         with:
           version: 9.15.3
           run_install: false
+          standalone: true
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.14.0
+          node-version: 22.20.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
@@ -48,7 +49,7 @@ jobs:
       - name: Verify
         run: pnpm verify
       - name: Upload coverage report
-        if: always()
+        if: ${{ success() || hashFiles('packages/pipeline/coverage/**') != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: pipeline-coverage
@@ -74,10 +75,11 @@ jobs:
         with:
           version: 9.15.3
           run_install: false
+          standalone: true
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.14.0
+          node-version: 22.20.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies without lifecycle scripts
@@ -157,6 +159,7 @@ jobs:
         with:
           version: 9.15.3
           run_install: false
+          standalone: true
       - name: Set up Node.js for release
         if: steps.release.outputs.exists != 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/discovery.yml
+++ b/.github/workflows/discovery.yml
@@ -11,9 +11,6 @@ on:
       - "llms-full.txt"
       - ".github/workflows/discovery.yml"
   pull_request:
-    paths:
-      - "llms.txt"
-      - "llms-full.txt"
   schedule:
     - cron: "0 6 * * 1"
   workflow_dispatch:

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -63,10 +63,11 @@ jobs:
         with:
           version: 9.15.3
           run_install: false
+          standalone: true
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22.14.0
+          node-version: 22.20.0
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies without lifecycle scripts

--- a/DEPENDENCY-LICENSES.md
+++ b/DEPENDENCY-LICENSES.md
@@ -23,3 +23,5 @@ CI generates two JSON artifacts: the complete workspace tree, including developm
 ## Platform-conditional dependencies
 
 The workspace toolchain includes optional native binaries selected by operating system and architecture, including Rollup, esbuild, and resolver bindings. Consequently a developer's installed inventory can contain a Darwin or Windows binary while the CI artifact records Linux x64. Every inventory records its OS, architecture, and lockfile SHA-256 so this difference is explicit. The published package's current production graph is platform-independent; the artifact-derived SBOM remains authoritative for each release.
+
+Dependency-consuming CI jobs use Node.js 22.20.0 because Rollup's selected Linux x64 optional compression binary requires Node.js 22.20 or newer. That development-only constraint does not raise the published package's Node.js 22.14 runtime floor.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -5,6 +5,7 @@ Agent-Safe Pipeline is a reference architecture in which AI agents propose actio
 ## Documentation
 
 - Overview: https://github.com/decionis/agent-safe-pipeline#readme
+- Contributor guide: https://github.com/decionis/agent-safe-pipeline/blob/master/CONTRIBUTING.md
 - Architecture: https://github.com/decionis/agent-safe-pipeline/blob/master/ARCHITECTURE.md
 - Threat model: https://github.com/decionis/agent-safe-pipeline/blob/master/THREAT-MODEL.md
 - Trust boundary: https://github.com/decionis/agent-safe-pipeline/blob/master/docs/trust-boundary.md

--- a/llms.txt
+++ b/llms.txt
@@ -5,6 +5,7 @@ Agent-Safe Pipeline is a reference architecture in which AI agents propose actio
 ## Documentation
 
 - Overview: https://github.com/decionis/agent-safe-pipeline#readme
+- Contributor guide: https://github.com/decionis/agent-safe-pipeline/blob/master/CONTRIBUTING.md
 - Architecture: https://github.com/decionis/agent-safe-pipeline/blob/master/ARCHITECTURE.md
 - Threat model: https://github.com/decionis/agent-safe-pipeline/blob/master/THREAT-MODEL.md
 - Trust boundary: https://github.com/decionis/agent-safe-pipeline/blob/master/docs/trust-boundary.md

--- a/scripts/CheckLicenses.mjs
+++ b/scripts/CheckLicenses.mjs
@@ -6,11 +6,22 @@ const APACHE_2_CANONICAL_SHA256 =
   "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30";
 const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const policy = JSON.parse(await readFile("license-policy.json", "utf8"));
-const inventory = spawnSync(pnpm, ["licenses", "list", "--json"], { encoding: "utf8" });
+const inventory = spawnSync(pnpm, ["licenses", "list", "--json"], {
+  encoding: "utf8",
+  env: { ...process.env, FORCE_COLOR: "0", NO_COLOR: "1" },
+  maxBuffer: 16 * 1024 * 1024,
+});
 
 if (inventory.status !== 0) {
-  process.stderr.write(inventory.stderr);
-  process.exit(inventory.status ?? 1);
+  const details = [
+    inventory.error?.stack,
+    inventory.stderr?.trim(),
+    inventory.stdout?.trim(),
+    inventory.signal ? `terminated by signal ${inventory.signal}` : undefined,
+  ].filter(Boolean);
+  throw new Error(
+    `pnpm license inventory failed with status ${inventory.status ?? "unknown"}${details.length > 0 ? `:\n${details.join("\n")}` : " without diagnostic output"}`,
+  );
 }
 
 const dependenciesByLicense = JSON.parse(inventory.stdout);


### PR DESCRIPTION
## Summary

- run dependency-consuming CI jobs on Node.js 22.20.0
- install the pinned pnpm 9.15.3 standalone executable
- surface stdout, stderr, signals, and spawn errors from licence inventory failures
- avoid masking an early verification failure with a second missing-coverage failure
- run the required `discovery` validation on every pull request

## Root causes

Rollup selects `@napi-rs/lzma-linux-x64-gnu@1.5.1` on GitHub's Linux x64 runners. That optional package requires Node.js 22.20 or newer, while CI used Node.js 22.14. pnpm therefore skipped the selected package during installation and its licence scanner later failed with `ERR_PNPM_MISSING_PACKAGE_INDEX_FILE`.

Branch protection also requires a check named `discovery`, but that workflow was restricted to pull requests changing `llms.txt` or `llms-full.txt`. Ordinary pull requests could never produce the required context and remained stuck on “Expected — Waiting for status to be reported.” The workflow now runs on every pull request. A valid contributor-guide entry updates both discovery manifests and bootstraps the check for this PR under the previous path filter.

These are the infrastructure failures currently blocking #23; they are unrelated to that PR's conformance-vector changes.

## Compatibility

The Node.js 22.20 requirement belongs only to the development toolchain. The published package's Node.js 22.14 runtime floor is unchanged.

## Validation

- full `pnpm verify` under Node.js 22.20.0
- discovery manifest and live-link validation
- pre-commit suite, including both dependency audits and the performance test
- deliberately failing pnpm executable confirmed the licence checker reports an actionable error

After this lands, #23 and #24 can be synchronized with `master`; both will then emit the required discovery context normally.
