### PR TITLE
Release v0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Decionis remains the authoritative decision service, Presence remains the human-
 
 ## Status
 
-The workspace package is versioned `0.1.1` but is not claimed as published until the registry release workflow succeeds. Install it from this workspace today. The canonical repository URL was verified on 2026-08-14; availability of future package releases is intentionally not fabricated in these docs.
+The workspace package is versioned `0.1.2` but is not claimed as published until the registry release workflow succeeds. Install it from this workspace today. The canonical repository URL was verified on 2026-08-14; availability of future package releases is intentionally not fabricated in these docs.
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-safe-pipeline-workspace",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "description": "Reference architecture for executing AI-agent actions through an independent authorization boundary.",
   "license": "Apache-2.0",

--- a/packages/pipeline/README.md
+++ b/packages/pipeline/README.md
@@ -4,7 +4,7 @@ TypeScript reference implementation of Agent-Safe Pipeline: capture an immutable
 
 ## Install
 
-The package is versioned `0.1.1` but is not claimed as published until a registry release succeeds. Consume it from the workspace today:
+The package is versioned `0.1.2` but is not claimed as published until a registry release succeeds. Consume it from the workspace today:
 
 ```bash
 pnpm install --frozen-lockfile

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decionis/agent-safe-pipeline",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "An execution architecture where AI agents may propose actions but cannot authorize their own execution.",
   "license": "Apache-2.0",
   "author": "Decionis, Inc.",


### PR DESCRIPTION
## What changed

- bump the workspace and public pipeline package from `0.1.1` to `0.1.2`
- align the root and package status documentation with the release version

## Why

This patch release cuts the security and robustness changes merged after `v0.1.1`, including authority-boundary hardening, immutable authorization evidence, single-use execution invariants, bounded intent traversal, verification-gate enforcement, Presence fail-closed handling, discovery restrictions, and bounded PR-bot API responses.

## Publication

Merging to `master` invokes the verified release job. npm publication remains disabled by repository configuration; the GitHub release will include the package tarball, CycloneDX SBOM, license inventories, checksums, signed Sigstore bundles, raw in-toto statements, and trusted root.

## Validation

- `gitleaks git . --config .gitleaks.toml --redact --verbose`
- `pnpm verify`
- `npm pack --dry-run --json` in `packages/pipeline`
