### PR TITLE
Add protected npm bootstrap workflow

### DIFF
--- a/.github/workflows/npm-bootstrap.yml
+++ b/.github/workflows/npm-bootstrap.yml
@@ -1,0 +1,121 @@
+name: Bootstrap npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirmation:
+        description: Type publish-v0.1.2 to authorize the one-time bootstrap
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-package-bootstrap
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.ref == 'refs/heads/master' &&
+      github.actor == 'ocularminds' &&
+      inputs.confirmation == 'publish-v0.1.2'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: npm-bootstrap
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+      - name: Check out trusted bootstrap verifier
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+      - name: Set up Node.js and npm registry
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.18.0
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Verify npm supports provenance and trusted publishing
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm_version="$(npm --version)"
+          node -e '
+            const [major, minor] = process.argv[1].split(".").map(Number);
+            if (major < 11 || (major === 11 && minor < 5)) process.exit(1);
+          ' "$npm_version"
+      - name: Download the fixed GitHub release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/npm-bootstrap"
+          gh release download v0.1.2 \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir "$RUNNER_TEMP/npm-bootstrap" \
+            --pattern decionis-agent-safe-pipeline-0.1.2.tgz \
+            --pattern SHA256SUMS \
+            --pattern agent-safe-pipeline-0.1.2.provenance.sigstore.json \
+            --pattern trusted_root.jsonl
+      - name: Verify checksum, package metadata, and GitHub attestation
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bootstrap="$RUNNER_TEMP/npm-bootstrap"
+          node scripts/VerifyBootstrapTarball.mjs \
+            "$bootstrap/decionis-agent-safe-pipeline-0.1.2.tgz" \
+            "$bootstrap/SHA256SUMS" \
+            "@decionis/agent-safe-pipeline" \
+            "0.1.2" \
+            "4cb14a3906f42fbea23fc4c9cc6450f731f09b18bc15eccbab2e723c30d1a92a"
+          gh attestation verify \
+            "$bootstrap/decionis-agent-safe-pipeline-0.1.2.tgz" \
+            --repo "$GITHUB_REPOSITORY" \
+            --bundle "$bootstrap/agent-safe-pipeline-0.1.2.provenance.sigstore.json" \
+            --custom-trusted-root "$bootstrap/trusted_root.jsonl"
+      - name: Publish the verified tarball once
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_BOOTSTRAP_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          package="@decionis/agent-safe-pipeline"
+          version="0.1.2"
+          tarball="$RUNNER_TEMP/npm-bootstrap/decionis-agent-safe-pipeline-0.1.2.tgz"
+          published_version="$(npm view "$package@$version" version 2>/dev/null || true)"
+          if [[ "$published_version" != "$version" ]]; then
+            if [[ -z "${NODE_AUTH_TOKEN:-}" ]]; then
+              echo "NPM_BOOTSTRAP_TOKEN is required for the initial publication." >&2
+              exit 1
+            fi
+            npm publish "$tarball" --access public --provenance --ignore-scripts
+          fi
+          test "$(npm view "$package@$version" version)" = "$version"
+      - name: Verify npm serves the identical release tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          registry="$RUNNER_TEMP/npm-registry-copy"
+          mkdir -p "$registry"
+          npm pack "@decionis/agent-safe-pipeline@0.1.2" \
+            --pack-destination "$registry" \
+            --ignore-scripts \
+            --silent
+          node scripts/VerifyBootstrapTarball.mjs \
+            "$registry/decionis-agent-safe-pipeline-0.1.2.tgz" \
+            "$RUNNER_TEMP/npm-bootstrap/SHA256SUMS" \
+            "@decionis/agent-safe-pipeline" \
+            "0.1.2" \
+            "4cb14a3906f42fbea23fc4c9cc6450f731f09b18bc15eccbab2e723c30d1a92a"
+          echo "Verified npm bootstrap package and exact release digest." >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,35 @@ Before merging a release change, exercise the same build and attestation path wi
 gh workflow run deploy.yml --ref <branch> -f release_dry_run=true
 ```
 
-The release can publish the exact tarball to npm without a long-lived token after the package exists. npm currently requires the package to exist before a trusted publisher can be configured, and `@decionis/agent-safe-pipeline` is not yet registered. An npm owner must bootstrap its first public version, then configure the package's trusted publisher for organization `decionis`, repository `agent-safe-pipeline`, workflow `deploy.yml`, and set the GitHub Actions repository variable `NPM_PUBLISH_ENABLED` to `true`. The workflow then uses OIDC, public access, and npm provenance. Without that explicit setup it creates a GitHub-only release and records that npm was skipped.
+The release can publish the exact tarball to npm without a long-lived token after the package
+exists. Until issue #19 is complete, keep `NPM_PUBLISH_ENABLED=false`. The one-time
+`npm-bootstrap.yml` workflow is pinned to the signed v0.1.2 release tarball and runs only from
+`master`, as `@ocularminds`, with the exact confirmation `publish-v0.1.2`, through the protected
+`npm-bootstrap` environment.
+
+An npm owner completes the bootstrap as follows:
+
+1. Create the `npm-bootstrap` GitHub environment with `@ocularminds` as required reviewer,
+   protected branches only, and administrator bypass disabled.
+2. Create a one-day granular npm token with read/write package-and-scope access to `@decionis` and
+   2FA bypass. Organization-management permission does not grant package publication permission.
+3. Store it only as the `NPM_BOOTSTRAP_TOKEN` environment secret, dispatch `npm-bootstrap.yml` from
+   `master`, enter `publish-v0.1.2`, and approve the environment deployment.
+4. Confirm the workflow verifies the GitHub checksum and attestation, publishes with provenance,
+   then downloads and verifies the registry tarball against SHA-256
+   `4cb14a3906f42fbea23fc4c9cc6450f731f09b18bc15eccbab2e723c30d1a92a`.
+5. Delete the environment secret, revoke the granular token, and remove `npm-bootstrap.yml` in the
+   next pull request.
+6. Configure npm trusted publishing for organization/user `decionis`, repository
+   `agent-safe-pipeline`, workflow filename `deploy.yml`, with `npm publish` permission. Then select
+   "Require two-factor authentication and disallow tokens" for traditional package publishing.
+7. Increment both manifests to `0.1.3-rc.1` in a release pull request. Temporarily set
+   `NPM_PUBLISH_ENABLED=true` immediately before merging it; `deploy.yml` creates the tag and
+   prerelease, so do not create the tag manually. Verify npm provenance and the registry/GitHub
+   tarball digest before leaving the variable enabled for stable releases.
+
+Without the completed bootstrap and trusted-publisher setup, `deploy.yml` creates a GitHub-only
+release and records that npm was skipped.
 
 To verify a release as an outsider, download all assets into an empty directory, run `shasum -a 256 -c SHA256SUMS`, then verify the tarball offline with the matching provenance bundle and `trusted_root.jsonl`:
 

--- a/SECURITY-EVIDENCE.md
+++ b/SECURITY-EVIDENCE.md
@@ -14,6 +14,7 @@ This map is an evidence index, not a claim of certification. Commands are run fr
 | Fixtures are synthetic by construction                      | `FIXTURE-PROVENANCE.md`, `scripts/CheckFixtureProvenance.mjs`       | `pnpm fixture:check`                                                                                                                                                          |
 | Browser framing controls                                    | Not applicable to the current Node.js library and CLI examples      | The repository has no HTTP listener, browser UI, redirects, or hosted demo; any future web surface must test CSP (including `frame-ancestors`) on success and error responses |
 | Releases are independently verifiable                       | `.github/workflows/deploy.yml`, `CONTRIBUTING.md`                   | Release tarball, SBOM, inventories, checksums, Sigstore bundles, raw in-toto statements, and trusted root are attached to the GitHub release                                  |
+| Initial npm publication is owner-gated                      | `.github/workflows/npm-bootstrap.yml`, bootstrap verifier           | Exact actor/ref/confirmation, non-bypassable protected environment approval, fixed release digest, GitHub attestation, short-lived secret, and registry digest verification   |
 | Vulnerabilities have private reporting and response targets | `SECURITY.md`                                                       | GitHub private vulnerability reporting and `security@decionis.com`                                                                                                            |
 | Repository changes are protected                            | `.github/CODEOWNERS`, GitHub branch protection and ruleset APIs     | Up-to-date required checks plus one code-owner review; the named maintainer has PR-only bypass to avoid deadlock                                                              |
 
@@ -36,7 +37,11 @@ The following gates were observed failing on 2026-08-15 before their controls we
 
 ## Known gaps and external dependencies
 
-- `@decionis/agent-safe-pipeline` does not yet exist on npm. npm requires a package to exist before trusted publishing can be configured, so its initial publication remains an npm-owner bootstrap task tracked in [issue #19](https://github.com/decionis/agent-safe-pipeline/issues/19). Subsequent releases remain disabled until `deploy.yml` is configured as the trusted publisher and the repository variable documented in `CONTRIBUTING.md` is enabled.
+- `@decionis/agent-safe-pipeline` does not yet exist on npm. The protected, one-time bootstrap path
+  is implemented, but an npm owner must supply and immediately revoke the temporary granular token,
+  remove the bootstrap workflow after use, configure `deploy.yml` as the trusted publisher, and
+  prove an OIDC prerelease before enabling stable publication. This remains tracked in
+  [issue #19](https://github.com/decionis/agent-safe-pipeline/issues/19).
 - Fixture provenance, trademark ownership, and disclosure targets require the written human decisions tracked in `PUBLICATION-SIGNOFFS.md`; automation cannot manufacture those approvals.
 - Repository-age, contributor-count, and historical review signals improve only with real project activity.
 - OpenSSF Best Practices registration requires an accountable Decionis owner to authenticate and self-certify the public evidence. It remains tracked in [issue #22](https://github.com/decionis/agent-safe-pipeline/issues/22) rather than represented as complete.

--- a/scripts/VerifyBootstrapTarball.mjs
+++ b/scripts/VerifyBootstrapTarball.mjs
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { readFile, stat } from "node:fs/promises";
+import { basename } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const maxTarballBytes = 10 * 1024 * 1024;
+const maxChecksumBytes = 100 * 1024;
+const maxArchiveEntries = 1_000;
+const maxCommandOutputBytes = 2 * 1024 * 1024;
+
+export function checksumFor(checksums, filename) {
+  const matches = [];
+  for (const line of checksums.split(/\r?\n/)) {
+    if (line.length === 0) continue;
+    const match = /^([0-9a-f]{64}) [ *](.+)$/i.exec(line);
+    if (match === null) throw new Error("BOOTSTRAP_CHECKSUMS_INVALID");
+    if (match[2] === filename) matches.push(match[1].toLowerCase());
+  }
+  if (matches.length !== 1) throw new Error("BOOTSTRAP_CHECKSUM_ENTRY_INVALID");
+  return matches[0];
+}
+
+export function validateArchiveEntries(entries) {
+  const names = entries.split(/\r?\n/).filter(Boolean);
+  if (names.length === 0 || names.length > maxArchiveEntries) {
+    throw new Error("BOOTSTRAP_ARCHIVE_ENTRY_COUNT_INVALID");
+  }
+
+  const unique = new Set();
+  for (const name of names) {
+    const segments = name.split("/");
+    if (
+      name.length > 500 ||
+      name.includes("\\") ||
+      segments[0] !== "package" ||
+      segments.some((segment) => segment === "" || segment === "." || segment === "..")
+    ) {
+      throw new Error("BOOTSTRAP_ARCHIVE_PATH_INVALID");
+    }
+    if (unique.has(name)) throw new Error("BOOTSTRAP_ARCHIVE_DUPLICATE_ENTRY");
+    unique.add(name);
+
+    const allowed =
+      name === "package/package.json" ||
+      name === "package/README.md" ||
+      name === "package/LICENSE" ||
+      name === "package/NOTICE" ||
+      name.startsWith("package/dist/");
+    if (!allowed) throw new Error("BOOTSTRAP_ARCHIVE_CONTENT_INVALID");
+  }
+
+  for (const required of [
+    "package/package.json",
+    "package/README.md",
+    "package/LICENSE",
+    "package/NOTICE",
+    "package/dist/Index.js",
+    "package/dist/Index.d.ts",
+  ]) {
+    if (!unique.has(required)) throw new Error("BOOTSTRAP_ARCHIVE_REQUIRED_FILE_MISSING");
+  }
+}
+
+export function validatePackageManifest(manifest, expectedName, expectedVersion) {
+  if (manifest === null || typeof manifest !== "object" || Array.isArray(manifest)) {
+    throw new Error("BOOTSTRAP_PACKAGE_MANIFEST_INVALID");
+  }
+  const expectedFiles = ["LICENSE", "NOTICE", "README.md", "dist"];
+  const actualFiles = Array.isArray(manifest.files) ? [...manifest.files].sort() : [];
+  if (
+    manifest.name !== expectedName ||
+    manifest.version !== expectedVersion ||
+    manifest.private === true ||
+    manifest.publishConfig?.access !== "public" ||
+    manifest.publishConfig?.provenance !== true ||
+    manifest.repository?.url !== "git+https://github.com/decionis/agent-safe-pipeline.git" ||
+    JSON.stringify(actualFiles) !== JSON.stringify(expectedFiles)
+  ) {
+    throw new Error("BOOTSTRAP_PACKAGE_MANIFEST_MISMATCH");
+  }
+}
+
+function runTar(arguments_) {
+  const result = spawnSync("tar", arguments_, {
+    encoding: "utf8",
+    maxBuffer: maxCommandOutputBytes,
+  });
+  if (result.status !== 0 || result.signal !== null || result.error !== undefined) {
+    throw new Error("BOOTSTRAP_ARCHIVE_INVALID");
+  }
+  return result.stdout;
+}
+
+export async function verifyBootstrapTarball({
+  tarballPath,
+  checksumsPath,
+  expectedName,
+  expectedVersion,
+  expectedSha256,
+}) {
+  if (!/^[0-9a-f]{64}$/.test(expectedSha256)) {
+    throw new Error("BOOTSTRAP_EXPECTED_DIGEST_INVALID");
+  }
+  const [tarballMetadata, checksumMetadata] = await Promise.all([
+    stat(tarballPath),
+    stat(checksumsPath),
+  ]);
+  if (!tarballMetadata.isFile() || tarballMetadata.size > maxTarballBytes) {
+    throw new Error("BOOTSTRAP_TARBALL_SIZE_INVALID");
+  }
+  if (!checksumMetadata.isFile() || checksumMetadata.size > maxChecksumBytes) {
+    throw new Error("BOOTSTRAP_CHECKSUMS_SIZE_INVALID");
+  }
+
+  const [tarball, checksums] = await Promise.all([
+    readFile(tarballPath),
+    readFile(checksumsPath, "utf8"),
+  ]);
+  const actualSha256 = createHash("sha256").update(tarball).digest("hex");
+  if (
+    actualSha256 !== expectedSha256 ||
+    checksumFor(checksums, basename(tarballPath)) !== expectedSha256
+  ) {
+    throw new Error("BOOTSTRAP_TARBALL_DIGEST_MISMATCH");
+  }
+
+  validateArchiveEntries(runTar(["-tzf", tarballPath]));
+  let manifest;
+  try {
+    manifest = JSON.parse(runTar(["-xOzf", tarballPath, "package/package.json"]));
+  } catch {
+    throw new Error("BOOTSTRAP_PACKAGE_MANIFEST_INVALID");
+  }
+  validatePackageManifest(manifest, expectedName, expectedVersion);
+  return Object.freeze({ sha256: actualSha256, name: expectedName, version: expectedVersion });
+}
+
+async function main() {
+  const [tarballPath, checksumsPath, expectedName, expectedVersion, expectedSha256] =
+    process.argv.slice(2);
+  if (!tarballPath || !checksumsPath || !expectedName || !expectedVersion || !expectedSha256) {
+    throw new Error(
+      "Usage: VerifyBootstrapTarball.mjs <tarball> <checksums> <name> <version> <sha256>",
+    );
+  }
+  const verified = await verifyBootstrapTarball({
+    tarballPath,
+    checksumsPath,
+    expectedName,
+    expectedVersion,
+    expectedSha256,
+  });
+  process.stdout.write(`Verified ${verified.name}@${verified.version} (${verified.sha256}).\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    process.stderr.write(
+      (error instanceof Error ? error.message : "BOOTSTRAP_VERIFY_FAILED") + "\n",
+    );
+    process.exitCode = 1;
+  });
+}

--- a/test/automation/VerifyBootstrapTarball.test.mjs
+++ b/test/automation/VerifyBootstrapTarball.test.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  checksumFor,
+  validateArchiveEntries,
+  validatePackageManifest,
+} from "../../scripts/VerifyBootstrapTarball.mjs";
+
+const requiredEntries = [
+  "package/package.json",
+  "package/README.md",
+  "package/LICENSE",
+  "package/NOTICE",
+  "package/dist/Index.js",
+  "package/dist/Index.d.ts",
+].join("\n");
+
+const packageManifest = {
+  name: "@decionis/agent-safe-pipeline",
+  version: "0.1.2",
+  files: ["dist", "README.md", "LICENSE", "NOTICE"],
+  repository: { url: "git+https://github.com/decionis/agent-safe-pipeline.git" },
+  publishConfig: { access: "public", provenance: true },
+};
+
+describe("VerifyBootstrapTarball", () => {
+  it("accepts the exact package surface and manifest", () => {
+    assert.doesNotThrow(() => validateArchiveEntries(requiredEntries));
+    assert.doesNotThrow(() =>
+      validatePackageManifest(packageManifest, "@decionis/agent-safe-pipeline", "0.1.2"),
+    );
+  });
+
+  it("rejects traversal, duplicate, and unexpected archive entries", () => {
+    for (const entry of [
+      "package/../outside",
+      "package/dist/Index.js\\extra",
+      "other/package.json",
+      "package/private.pem",
+    ]) {
+      assert.throws(() => validateArchiveEntries(requiredEntries + "\n" + entry), /BOOTSTRAP_/);
+    }
+    assert.throws(
+      () => validateArchiveEntries(requiredEntries + "\npackage/dist/Index.js"),
+      /BOOTSTRAP_ARCHIVE_DUPLICATE_ENTRY/,
+    );
+  });
+
+  it("rejects a missing required package file", () => {
+    assert.throws(
+      () => validateArchiveEntries(requiredEntries.replace("package/NOTICE\n", "")),
+      /BOOTSTRAP_ARCHIVE_REQUIRED_FILE_MISSING/,
+    );
+  });
+
+  it("rejects publication metadata drift", () => {
+    for (const changed of [
+      { ...packageManifest, version: "0.1.3" },
+      { ...packageManifest, private: true },
+      { ...packageManifest, files: ["dist", "README.md", "LICENSE", "NOTICE", "extra"] },
+      { ...packageManifest, publishConfig: { access: "restricted", provenance: true } },
+      { ...packageManifest, repository: { url: "https://example.invalid/project" } },
+    ]) {
+      assert.throws(
+        () => validatePackageManifest(changed, "@decionis/agent-safe-pipeline", "0.1.2"),
+        /BOOTSTRAP_PACKAGE_MANIFEST_MISMATCH/,
+      );
+    }
+  });
+
+  it("requires exactly one valid checksum entry", () => {
+    const digest = "a".repeat(64);
+    assert.equal(checksumFor(`${digest}  package.tgz\n`, "package.tgz"), digest);
+    assert.throws(() => checksumFor(`${digest}  other.tgz\n`, "package.tgz"), /CHECKSUM_ENTRY/);
+    assert.throws(
+      () => checksumFor(`${digest}  package.tgz\n${digest}  package.tgz\n`, "package.tgz"),
+      /CHECKSUM_ENTRY/,
+    );
+    assert.throws(() => checksumFor("not-a-checksum\n", "package.tgz"), /CHECKSUMS_INVALID/);
+  });
+});


### PR DESCRIPTION
## What changed

- adds a one-time npm bootstrap workflow restricted to master, ocularminds, an exact confirmation, and the protected npm-bootstrap environment
- pins publication to the attested v0.1.2 release tarball and its verified SHA-256
- validates archive paths, contents, package metadata, checksum, and GitHub attestation before publication
- exposes the temporary npm token only to the publish step and disables lifecycle scripts
- downloads the public npm tarball afterward and requires byte-identical SHA-256
- documents token revocation, trusted-publisher setup, prerelease proof, and workflow removal

## Why

The package must exist on npm before deploy.yml can be registered as its trusted OIDC publisher. Re-running v0.1.2 cannot bootstrap it because the existing release short-circuits the normal release job, while workflow dispatch intentionally never publishes.

## Validation

- pnpm verify
- pnpm test:automation
- actionlint .github/workflows/npm-bootstrap.yml
- verifier executed successfully against the real v0.1.2 GitHub release asset

## Owner follow-up

Keep NPM_PUBLISH_ENABLED=false. After merge, create the one-day npm token as documented, store it as the npm-bootstrap environment secret, dispatch the workflow once, then revoke and remove all bootstrap-only state. This advances #19 but does not close it until the OIDC prerelease proof succeeds.
