### PR TITLE
Prepare citable v0.1.3 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,33 @@
+cff-version: 1.2.0
+message: >-
+  If you use the Agent-Safe Pipeline or its Decision Dossier corpus, please
+  cite the archived release.
+title: >-
+  Agent-Safe Pipeline: Reproducible Execution-Authority Reference Architecture
+  and Decision Dossier Corpus
+type: software
+authors:
+  - family-names: Jejelowo
+    given-names: Festus B.
+    affiliation: Decionis, Inc.
+    orcid: https://orcid.org/0009-0006-4895-6046
+version: 0.1.3
+date-released: 2026-09-05
+license: Apache-2.0
+repository-code: https://github.com/decionis/agent-safe-pipeline
+url: https://github.com/decionis/agent-safe-pipeline
+abstract: >-
+  A runnable reference architecture in which AI agents propose actions but
+  cannot authorize their own execution. The release includes an independently
+  reproducible synthetic Decision Dossier corpus with canonical bytes,
+  SHA-256 digests, Ed25519 signatures, a deliberately published corpus key,
+  execution-bound proof vectors, and negative tamper cases.
+keywords:
+  - execution authority
+  - agentic AI
+  - Decision Dossier
+  - deterministic policy evaluation
+  - cryptographic verification
+  - Ed25519
+  - RFC 8785
+  - reproducible corpus

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-safe-pipeline-workspace",
-  "version": "0.1.3-rc.2",
+  "version": "0.1.3",
   "private": true,
   "description": "Reference architecture for executing AI-agent actions through an independent authorization boundary.",
   "license": "Apache-2.0",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decionis/agent-safe-pipeline",
-  "version": "0.1.3-rc.2",
+  "version": "0.1.3",
   "description": "An execution architecture where AI agents may propose actions but cannot authorize their own execution.",
   "license": "Apache-2.0",
   "author": "Decionis, Inc.",


### PR DESCRIPTION
## Summary

- promote the tested `0.1.3-rc.2` line to stable `0.1.3`
- add CFF 1.2 citation metadata for the reference implementation and reproducible Decision Dossier corpus
- bind the release author to ORCID `0009-0006-4895-6046`

Merging this PR intentionally activates the protected release workflow. It will publish `@decionis/agent-safe-pipeline@0.1.3`, create the keylessly signed `v0.1.3` GitHub Release with attestations/SBOM/checksums, and—after the repository is enabled in Zenodo—archive the immutable software/corpus release under its own DOI.

This DOI is deliberately distinct from the technical note DOI `10.5281/zenodo.22081954`.

## Verification

- `CITATION.cff` validates against the official CFF 1.2.0 JSON Schema
- workspace and package versions are aligned at `0.1.3`
- Prettier and `git diff --check` pass
- the release dry-run and protected PR checks will exercise the full verification/build/attestation path before merge
