### PR TITLE
Model auditable provider outcomes and publish maintenance policy

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -38,7 +38,9 @@ Agent proposal                         runtime identity/config
 
 `PresenceApprovalCoordinator` presents the action, target, and intent hash to the human. Only a terminal receipt dossier is accepted as evidence. The coordinator sends that evidence back to Decionis; it never turns approval into ALLOW itself.
 
-`SafeExecutor` checks ALLOW, exact intent binding, and the existence of a grant. Its verifier atomically consumes the grant before a registered handler can run. A handler is registered by trusted application startup code and the registry is sealed before use.
+`SafeExecutor` checks ALLOW, exact intent binding, and the existence of a grant. Its verifier atomically consumes the grant before a registered handler can run. A handler is registered by trusted application startup code and the registry is sealed before use. The handler's one-shot provider-dispatch boundary distinguishes a definite pre-dispatch failure from an unknown post-dispatch outcome; read-only reconciliation uses the intent-bound idempotency key and never retries a side effect. See [execution outcomes](./docs/execution-outcomes.md).
+
+`AuditRecorder` sends deeply immutable, bounded, redacted lifecycle events to a consumer sink. It correlates intent, decision, dossier, grant, policy-revision, and execution evidence without copying raw parameters, provider results, credentials, or execution tokens. Its sink policy can preserve availability or require evidence before dispatch, but a sink failure can never allow a blocked action or cause duplicate execution. See [audit events](./docs/audit-events.md).
 
 `ShadowPipeline` observes existing execution and obtains a hypothetical authority decision without granting the shadow result execution authority. Its output is labeled `SHADOW` to prevent accidental enforcement claims.
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,45 @@
+# Maintenance and version support
+
+This policy describes the support offered for Agent-Safe Pipeline releases. It is a maintenance
+commitment for this public reference implementation, not a service-level agreement for the
+Decionis hosted service.
+
+## Supported release lines
+
+| Release line                   | Status          | Support                                                                  |
+| ------------------------------ | --------------- | ------------------------------------------------------------------------ |
+| Latest published `0.x` release | Supported       | Security fixes and corrections for trust-boundary defects                |
+| Older `0.x` releases           | End of life     | No routine fixes; upgrade to the latest release                          |
+| Prereleases such as `-rc.N`    | Evaluation only | May be replaced without a backport; not supported for production use     |
+| Unreleased `master`            | Development     | Receives changes through reviewed pull requests; not a supported release |
+
+Until `1.0.0`, only the latest published `0.x` release is supported. A security fix normally ships
+as a new patch release on that line. If a vulnerability cannot be fixed without changing the
+documented trust boundary or public API, maintainers publish migration guidance and choose the
+smallest responsible semantic-version increment. Older versions become end of life when the
+replacement release is published unless a security advisory states a short, explicit overlap
+period.
+
+End-of-life versions remain available as historical artifacts, but their presence does not imply
+support. Security reports concerning an end-of-life version are assessed against the latest
+supported release; reporters may be asked to reproduce the issue there.
+
+## Change and documentation policy
+
+Every release change must update both workspace and package versions and pass the release checks in
+[CONTRIBUTING.md](./CONTRIBUTING.md). The same pull request must update documentation when it
+changes any of the following:
+
+- the proposal, authorization, approval, grant-consumption, or execution trust boundary;
+- public exports, wire contracts, runtime requirements, or supported configurations;
+- failure behavior, security assumptions, accepted risks, or operator responsibilities; or
+- release, verification, maintenance, or end-of-life procedures.
+
+Reviewers compare affected code with `README.md`, `ARCHITECTURE.md`, `THREAT-MODEL.md`,
+`SECURITY.md`, package documentation, and the public evidence map. A release must not claim a
+planned feature as available. Released capabilities are linked to immutable tags or release
+artifacts; future work remains labeled committed or exploratory in [ROADMAP.md](./ROADMAP.md).
+
+This policy is reviewed before each stable release and whenever the trust boundary, runtime floor,
+or release process changes. Material policy changes are announced in release notes and take effect
+when merged unless a later effective date is stated.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,50 @@
+# Roadmap
+
+This roadmap is current as of 2026-09-07. It distinguishes work maintainers intend to deliver from
+ideas that still require design or resourcing. It is not a promise of dates or hosted-service
+availability; priorities can change when security or compatibility work intervenes.
+
+## Released
+
+- `v0.1.0` established immutable intent capture, independent ALLOW/ESCALATE/BLOCK decisions,
+  Presence evidence, single-use execution grants, and a sealed trusted action registry.
+- `v0.1.2` added a verifiable release path with SBOM, license inventory, provenance, checksums, and
+  clean-consumer installation.
+- `v0.1.3` added signed release tags, reproducible package builds, citable release metadata, and a
+  synthetic Decision Dossier conformance corpus.
+
+See [GitHub Releases](https://github.com/decionis/agent-safe-pipeline/releases) and the
+[release-verification guide](./CONTRIBUTING.md#releases) for immutable artifacts and verification
+instructions.
+
+## Committed next work
+
+Committed means accepted maintenance or security work that maintainers intend to complete. It does
+not imply a release date.
+
+- Isolate test-only authorization helpers behind an explicit package subpath.
+- Add packed-package public API compatibility and real HTTP contract gates.
+- Make shadow evaluation failure-isolated, bounded, and unambiguously observational.
+- Continue closing documented OpenSSF Silver evidence gaps without overstating controls that are
+  not yet independently exercised.
+
+The open issue tracker is the source of truth for scope, acceptance criteria, and progress. An item
+leaves this section when it is released, rejected with rationale, or explicitly moved back to
+exploration.
+
+## Exploratory
+
+Exploratory items have no delivery commitment. They require protocol, threat-model, or ecosystem
+validation before maintainers accept an implementation plan.
+
+- Cross-language implementations of the canonical intent and execution-evidence contracts.
+- Additional provider adapters and deployment reference architectures.
+- Decision-chain visualization and offline audit tooling beyond the current dossier verifier.
+- A future stable `1.0` compatibility contract after real integration feedback.
+
+## Updating this roadmap
+
+Roadmap changes use reviewed pull requests. Each change must preserve the distinction between
+released, committed, and exploratory work; link a tracking issue for newly committed scope; and
+avoid dates unless an accountable maintainer has accepted them. Release pull requests move shipped
+items to **Released** and link the resulting tag or release evidence.

--- a/SECURITY-EVIDENCE.md
+++ b/SECURITY-EVIDENCE.md
@@ -22,6 +22,8 @@ This map is an evidence index, not a claim of independent certification. The Ope
 | Vulnerabilities have private reporting and response targets | `SECURITY.md`                                                               | GitHub private vulnerability reporting and `security@decionis.com`                                                                                                            |
 | Repository changes are protected                            | `.github/CODEOWNERS`, GitHub branch protection and ruleset APIs             | Up-to-date required checks plus one code-owner review; the named maintainer has PR-only bypass to avoid deadlock                                                              |
 | Contribution and governance authority are explicit          | `GOVERNANCE.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`                    | The `DCO` workflow enforces author-matching sign-offs; role, escalation, access-continuity, and bus-factor limits are public                                                  |
+| Supported versions and roadmap status are public            | `MAINTENANCE.md`, `ROADMAP.md`, `CONTRIBUTING.md`                           | Support, prerelease and end-of-life handling, documentation-review triggers, released evidence, committed work, and exploratory work are explicitly separated                 |
+| Vulnerability response and reporter credit are documented   | `SECURITY.md`, `docs/vulnerability-response.md`                             | Private triage, severity, ownership, coordinated disclosure, release, duplicate/invalid/embargo handling, credit choices, and a synthetic tabletop checklist are public       |
 | OpenSSF Best Practices Passing evidence is public           | README badge, [project 14098](https://www.bestpractices.dev/projects/14098) | The active record identifies this canonical repository, has achieved Passing, and publishes unanswered Silver criteria for follow-up                                          |
 
 ## Negative-control record
@@ -52,11 +54,9 @@ The following gates were observed failing on 2026-08-15 before their controls we
 - The project has a lead and a maintainer, but code-owner, private-report, npm-recovery, and
   emergency-release authority are not independently available to two people. `GOVERNANCE.md`
   therefore records OpenSSF access continuity and bus factor as unmet rather than overstating them.
-- The OpenSSF Best Practices record has achieved Passing. Remaining Silver evidence and controls are
-  tracked in [#46](https://github.com/decionis/agent-safe-pipeline/issues/46),
-  [#47](https://github.com/decionis/agent-safe-pipeline/issues/47),
-  [#51](https://github.com/decionis/agent-safe-pipeline/issues/51), and
-  [#52](https://github.com/decionis/agent-safe-pipeline/issues/52).
+- The OpenSSF Best Practices record has achieved Passing. The public maintenance, roadmap, and
+  vulnerability-response evidence is checked in here; remaining independent continuity and other
+  Silver controls must stay marked unmet until their real-world prerequisites are satisfied.
 - The release job alone receives job-scoped `contents: write` so it can create tags and GitHub Releases after verification. OpenSSF Scorecard does not recognize the custom `gh release create` path as a release exception, so its Token-Permissions check may continue to report that necessary permission even though every workflow declares a read-only default.
 - The synthetic dossier corpus proves the public verifier's deterministic behavior, not that a
   production dossier verifies. The root and corpus READMEs therefore publish a separate command for

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,6 +8,11 @@ The accountable data and security owner for reports and the response targets bel
 
 We will coordinate remediation and publication through a GitHub Security Advisory when practical and credit reporters who want attribution. There is no promise of a bug bounty unless separately agreed in writing.
 
+Reporters may request a specific public credit, anonymous credit, or no credit. Duplicate, invalid,
+and embargoed reports are handled without exposing another reporter or private report content. The
+maintainer triage, remediation, disclosure, release, and tabletop-exercise process is documented in
+the [vulnerability response workflow](./docs/vulnerability-response.md).
+
 ## Response and disclosure targets
 
 These are service targets rather than contractual guarantees. Timing starts when a report reaches either private channel above.
@@ -26,7 +31,9 @@ Active exploitation, credential exposure, or material user risk may require fast
 
 ## Supported versions
 
-Before the first stable release, only the latest tagged `0.x` version receives security fixes. Consumers should pin exact versions and review release notes.
+Before the first stable release, only the latest tagged `0.x` version receives security fixes.
+Consumers should pin exact versions and review release notes. Prerelease and end-of-life behavior is
+defined in the [maintenance and version-support policy](./MAINTENANCE.md).
 
 ## Integration requirements
 

--- a/THREAT-MODEL.md
+++ b/THREAT-MODEL.md
@@ -15,18 +15,20 @@ Compromise of the trusted executor host or downstream provider is outside what t
 
 ## Threats and controls
 
-| Threat                                           | Control                                                                        | Residual risk                                                                              |
-| ------------------------------------------------ | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
-| Prompt injection asks the agent to ignore policy | Gate is outside the prompt and independently decides                           | A developer can still bypass the architecture                                              |
-| Agent changes tool arguments after approval      | Exact canonical parameters and target bind to the intent hash                  | Non-deterministic downstream interpretation must be avoided                                |
-| Approval for action A is swapped onto action B   | Presence display and receipt bind the exact hash; Decionis re-verifies         | Presence integration must preserve immutable fields                                        |
-| Old approval or grant is replayed                | Short expiry, hash-bound idempotency key, `jti`, and atomic single-use consume | A downstream timeout after consume needs a fresh decision or provider idempotency recovery |
-| Agent calls the provider directly                | Provider credential and egress live behind the executor                        | Network policy must actually prevent agent egress                                          |
-| Agent chooses arbitrary code to run              | Sealed action registry; no agent-supplied callback                             | Trusted registration code remains security-critical                                        |
-| Authority is unavailable or malformed            | Timeout, bounded response, strict validation, fail closed                      | Reduced availability is accepted over unauthorized execution                               |
-| JSON ambiguity or prototype pollution            | Strict schemas, forbidden keys, bounded canonical JSON, exact SHA-256 binding  | Cross-language canonicalization requires conformance tests                                 |
-| Human approves misleading content                | Action, target, and exact hash are mandatory display fields                    | A human can still make a poor but authentic decision                                       |
-| Shadow result is mistaken for authorization      | Separate `SHADOW` result type and no execution grant                           | Consumer logs/UI must preserve the label                                                   |
+| Threat                                            | Control                                                                         | Residual risk                                                                         |
+| ------------------------------------------------- | ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Prompt injection asks the agent to ignore policy  | Gate is outside the prompt and independently decides                            | A developer can still bypass the architecture                                         |
+| Agent changes tool arguments after approval       | Exact canonical parameters and target bind to the intent hash                   | Non-deterministic downstream interpretation must be avoided                           |
+| Approval for action A is swapped onto action B    | Presence display and receipt bind the exact hash; Decionis re-verifies          | Presence integration must preserve immutable fields                                   |
+| Old approval or grant is replayed                 | Short expiry, hash-bound idempotency key, `jti`, and atomic single-use consume  | Provider records must remain available for reconciliation                             |
+| Agent calls the provider directly                 | Provider credential and egress live behind the executor                         | Network policy must actually prevent agent egress                                     |
+| Agent chooses arbitrary code to run               | Sealed action registry; no agent-supplied callback                              | Trusted registration code remains security-critical                                   |
+| Authority is unavailable or malformed             | Timeout, bounded response, strict validation, fail closed                       | Reduced availability is accepted over unauthorized execution                          |
+| JSON ambiguity or prototype pollution             | Strict schemas, forbidden keys, bounded canonical JSON, exact SHA-256 binding   | Cross-language canonicalization requires conformance tests                            |
+| Human approves misleading content                 | Action, target, and exact hash are mandatory display fields                     | A human can still make a poor but authentic decision                                  |
+| Shadow result is mistaken for authorization       | Separate `SHADOW` result type and no execution grant                            | Consumer logs/UI must preserve the label                                              |
+| Provider accepts an action but loses the response | One-shot dispatch tracking returns unknown; read-only lookup uses the bound key | A provider without idempotency or durable lookup may remain permanently ambiguous     |
+| Audit sink leaks or changes execution             | Redacted allowlist, bounded one-shot delivery, explicit failure policy          | Best-effort delivery can leave evidence gaps; strict delivery can reduce availability |
 
 ## Credential architecture
 
@@ -52,15 +54,20 @@ The agent runtime should have denied-by-default network egress. Open only the pr
 - Presence approval alone cannot execute.
 - Production cannot instantiate fixture authority or verifier.
 - Authority outage, timeout, oversized response, and invalid JSON all block.
+- A provider exception before dispatch is distinct from an unknown exception after dispatch.
+- Reconciliation cannot initiate a side effect and concurrent lookups share one in-flight request.
+- Audit events contain no token, raw parameters, raw context, or provider result by default.
 
 ## Accepted risks
 
 These risks are accepted for the reference library rather than silently presented as mitigated. The Decionis maintainers own them and review the table before every stable release or when the trust boundary changes.
 
-| Accepted risk                                              | Rationale                                                                        | Required compensating control                                                                             | Review trigger                                          |
-| ---------------------------------------------------------- | -------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| A trusted executor host can bypass the library             | Host compromise cannot be solved inside an in-process package                    | Isolate the executor, deny agent egress, restrict provider credentials, and monitor direct provider calls | Executor deployment or credential architecture changes  |
-| Authority failure reduces availability                     | Failing open would permit unauthorized execution                                 | Fail closed and require a fresh decision after recovery                                                   | Availability target or timeout policy changes           |
-| A human can approve misleading but correctly bound content | Cryptographic binding proves what was approved, not that the judgment was wise   | Display the exact action, target, amount, and hash; apply policy limits before escalation                 | Approval UX or Presence receipt schema changes          |
-| Cross-language canonicalization can drift                  | Multiple implementations may encode otherwise equivalent JSON differently        | Keep the published conformance vector and require contract tests in every implementation                  | Protocol or canonicalization changes                    |
-| In-memory replay protection is process-local               | The implementation is a development primitive, not a distributed consume service | Production uses the authority's atomic consume endpoint and provider idempotency                          | Any proposal to use `InMemoryReplayStore` in production |
+| Accepted risk                                              | Rationale                                                                        | Required compensating control                                                                                  | Review trigger                                          |
+| ---------------------------------------------------------- | -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| A trusted executor host can bypass the library             | Host compromise cannot be solved inside an in-process package                    | Isolate the executor, deny agent egress, restrict provider credentials, and monitor direct provider calls      | Executor deployment or credential architecture changes  |
+| Authority failure reduces availability                     | Failing open would permit unauthorized execution                                 | Fail closed and require a fresh decision after recovery                                                        | Availability target or timeout policy changes           |
+| A human can approve misleading but correctly bound content | Cryptographic binding proves what was approved, not that the judgment was wise   | Display the exact action, target, amount, and hash; apply policy limits before escalation                      | Approval UX or Presence receipt schema changes          |
+| Cross-language canonicalization can drift                  | Multiple implementations may encode otherwise equivalent JSON differently        | Keep the published conformance vector and require contract tests in every implementation                       | Protocol or canonicalization changes                    |
+| In-memory replay protection is process-local               | The implementation is a development primitive, not a distributed consume service | Production uses the authority's atomic consume endpoint and provider idempotency                               | Any proposal to use `InMemoryReplayStore` in production |
+| A post-dispatch provider outcome can remain unknown        | A response loss cannot safely be interpreted as either success or failure        | Use provider-native idempotency and read-only reconciliation; require a fresh grant for a new side effect      | Handler or provider integration changes                 |
+| Best-effort audit delivery can leave evidence gaps         | Forcing every sink to be available can prevent otherwise safe execution          | Use bounded delivery, monitor sink health, and choose strict pre-dispatch delivery where evidence is mandatory | Audit retention or compliance requirements change       |

--- a/docs/audit-events.md
+++ b/docs/audit-events.md
@@ -1,0 +1,101 @@
+# Redacted lifecycle audit events
+
+`AuditRecorder` provides one versioned integration point for intent capture, authority decisions,
+Presence evidence, grant consumption, execution, ambiguous outcomes, and reconciliation. Events use
+schema `agent-safe.audit/1`, are deeply frozen before delivery, and contain bounded correlation and
+evaluation references rather than raw business payloads.
+
+## Event contract
+
+Every event contains an event ID and timestamp; an explicit `AUTHORITATIVE`, `OBSERVATIONAL`, or
+`NON_AUTHORITATIVE` classification; intent and optional correlation IDs; bounded reason codes and
+duration; and empty-by-default metadata. Decision events also carry the verdict, decision and
+dossier IDs, an evaluation ID, a material-input digest, and an optional immutable policy revision.
+Grant and execution events add the consumed grant ID. They never include execution tokens, API
+keys, raw intent parameters or context, raw targets, or provider results.
+
+An observational event remains observational after JSON serialization. Its shape is an audit
+record, not a `GateDecision`, and `SafeExecutor` rejects it if application code attempts an unsafe
+cast. Presence events are `NON_AUTHORITATIVE`: a human receipt is evidence for Decionis
+re-evaluation, never execution authority.
+
+## Sink configuration
+
+```ts
+const audit = new AuditRecorder({
+  sink: {
+    write: async (event) => securityEventQueue.send(event),
+  },
+  timeoutMs: 100,
+  failurePolicy: "BEST_EFFORT",
+  metadataAllowlist: ["deployment_region"],
+});
+
+const executor = new SafeExecutor(registry, verifier, audit);
+```
+
+Each event gets one bounded sink attempt. Exceptions and timeouts are converted to a failed
+delivery and are never retried by the library, so sink health cannot reorder events or duplicate a
+provider action. `BEST_EFFORT` preserves execution availability. `REQUIRE_BEFORE_EXECUTION` blocks
+before grant consumption if initial evidence cannot be recorded, and stops after consumption but
+before provider dispatch if grant or execution-start evidence cannot be recorded. A post-dispatch
+sink failure never changes or retries the provider outcome.
+
+`SafeExecutor` emits this order when the applicable stages occur:
+
+```text
+INTENT_CAPTURED
+  -> AUTHORITY_DECISION | AUTHORITY_FAILED_CLOSED
+  -> EXECUTION_BLOCKED
+     or GRANT_CONSUMED -> EXECUTION_STARTED
+          -> EXECUTION_COMPLETED
+             | EXECUTION_FAILED_BEFORE_DISPATCH
+             | EXECUTION_OUTCOME_UNKNOWN
+  -> RECONCILIATION_COMPLETED
+     | RECONCILIATION_NOT_EXECUTED
+     | RECONCILIATION_UNKNOWN
+```
+
+`PresenceApprovalCoordinator` emits `PRESENCE_ESCALATED` and `PRESENCE_RESOLVED` with
+`NON_AUTHORITATIVE` classification. `IntentCapture.captureAndAudit` is available when capture must be
+recorded even if the caller never reaches `SafeExecutor`; avoid using both automatic paths if the
+sink treats two capture observations as duplicates.
+
+## Metadata and redaction
+
+Consumer metadata is dropped unless its top-level key is explicitly allowlisted. Keys suggesting
+tokens, credentials, passwords, secrets, authorization, raw parameters/context, or provider results
+are always excluded even if listed. An optional redaction hook may replace or omit remaining values.
+The post-redaction object is limited to 4 KiB, depth four, 50 entries, arrays of 20, and strings of
+500 characters. Invalid metadata fails that event delivery; it never relaxes an authorization
+decision.
+
+## Policy revision and evidence retention
+
+An authority-decision event may attach `{policyId, revisionId, version, digest}`. `revisionId` must
+be immutable; aliases such as `current` and `latest` are rejected. The digest commits to the exact
+evaluation semantics without copying confidential policy rules into the audit stream. The event
+also commits to the material input digest and points to the Decision Dossier as evidence when one is
+available.
+
+Once a revision has participated in an authoritative decision, do not mutate it in place. A hotfix
+creates a new revision identity and digest. Keep the referenced revision or an immutable archival
+representation for at least as long as dependent authoritative evidence is retained:
+
+```text
+retained authoritative evidence => verifiable referenced policy revision
+```
+
+Before deleting a live revision, verify that every retained event can resolve an archived policy
+artifact whose digest matches the event. Historical replay must select the pinned revision, never
+the current alias. Missing artifacts or digest mismatches are evidence-retention failures, not a
+reason to reinterpret the historical decision using new policy.
+
+`AuditPolicyRevisionVerifier` performs that bounded lookup through a consumer-supplied resolver and
+reports `VERIFIED`, `MISSING`, `DIGEST_MISMATCH`, `IDENTITY_MISMATCH`, `UNAVAILABLE`, or
+`NOT_REFERENCED`. A verified result returns the exact archived artifact reference selected by the
+event's policy and revision IDs for an authorized replay system.
+
+The audit record is reproducible evidence, not necessarily self-contained evidence: an authorized
+verifier combines its commitments with retained policy and dossier artifacts. Confidential rules
+and evaluation inputs do not need to be duplicated into each event.

--- a/docs/execution-outcomes.md
+++ b/docs/execution-outcomes.md
@@ -1,0 +1,63 @@
+# Execution outcomes and reconciliation
+
+Grant consumption and provider execution are separate boundaries. A single-use grant is consumed
+before a handler runs, but a provider may accept a side effect and lose the response. Treating that
+case as an ordinary failure invites a duplicate retry.
+
+`SafeExecutor.run` therefore returns one of four outcomes:
+
+| Outcome                  | Meaning                                                                          | May the caller retry the side effect? |
+| ------------------------ | -------------------------------------------------------------------------------- | ------------------------------------- |
+| `BLOCKED`                | No valid execution authority reached the handler                                 | Obtain or correct authority first     |
+| `FAILED_BEFORE_DISPATCH` | A grant was consumed, but the trusted provider-dispatch boundary was not crossed | Only with a fresh decision and grant  |
+| `COMPLETED`              | The trusted handler returned a provider result                                   | No; return or persist that result     |
+| `UNKNOWN_AFTER_DISPATCH` | Dispatch began, but completion could not be proved                               | No; reconcile first                   |
+
+`executed` is `true`, `false`, or `null` respectively so an unknown outcome cannot be mistaken for a
+definite failure.
+
+## Trusted handler contract
+
+Put the provider side effect inside `dispatch.run`. The callback receives the idempotency key that
+was supplied by trusted intent capture and bound into the canonical intent. The dispatch wrapper
+permits one invocation and records the point after which an exception is ambiguous.
+
+```ts
+registry.register("refund_order", {
+  parametersSchema: RefundSchema,
+  execute: async ({ parameters, dispatch }) =>
+    await dispatch.run(async (idempotencyKey) => provider.refund(parameters, { idempotencyKey })),
+  reconcile: async ({ idempotencyKey }) => {
+    const existing = await provider.findRefund(idempotencyKey);
+    if (existing) return { status: "COMPLETED", result: existing };
+    if (await provider.provesNoRefund(idempotencyKey)) return { status: "NOT_EXECUTED" };
+    return { status: "UNKNOWN" };
+  },
+});
+```
+
+The handler is trusted code. Calling the provider outside `dispatch.run`, using a different
+idempotency key, or initiating a side effect from `reconcile` violates the trust boundary. Neither
+the dispatch nor reconciliation context contains the Decionis execution token or provider
+credentials.
+
+## Recovery
+
+An unknown result includes an immutable `agent-safe.recovery/1` reference containing only the bound
+intent, decision, dossier, grant, expiry, and idempotency identifiers. Pass that reference and the
+original captured intent to `SafeExecutor.reconcile`.
+
+Reconciliation is a provider lookup, not authorization. It may return the original completed
+result, prove that no action occurred, or remain unknown. Concurrent reconciliation calls for the
+same intent and idempotency key share one in-flight lookup. A rejected, malformed, or unavailable
+lookup remains `UNKNOWN_AFTER_DISPATCH`; raw provider errors are not exposed.
+
+No path automatically invokes the handler a second time. Even when reconciliation proves that no
+action occurred, the prior grant remains consumed. A new side effect requires a fresh authority
+decision and fresh grant. If reconciliation returns the original provider result, return it without
+new authorization or execution.
+
+Caller cancellation after provider dispatch cannot prove that the action stopped. Preserve the
+unknown result or its recovery reference and reconcile it. Production handlers should also use the
+same bound key with the provider's native idempotency facility and retain provider records long
+enough for the application's recovery window.

--- a/docs/vulnerability-response.md
+++ b/docs/vulnerability-response.md
@@ -1,0 +1,97 @@
+# Vulnerability response workflow
+
+This is the maintainer runbook behind the public targets in [SECURITY.md](../SECURITY.md). It must
+be used only with synthetic exercise data or inside a private GitHub Security Advisory. Never copy
+report details, credentials, customer data, or exploit material into public issues, pull requests,
+logs, or test fixtures.
+
+## Intake and ownership
+
+1. Acknowledge the reporter through the channel that received the report and assign a private case
+   identifier. Record whether the reporter requests credit, a specific attribution, or anonymity.
+2. The security owner named in `SECURITY.md` assigns an uninvolved responder. Limit advisory and
+   repository access to people needed for validation and remediation.
+3. Preserve the original report and relevant version or commit identifiers. Ask for the minimum
+   additional evidence needed, using a secure transfer method for sensitive material.
+
+## Triage and severity
+
+The responder reproduces the issue against a supported version in an isolated environment and
+records affected versions, prerequisites, trust-boundary impact, exploitability, data or action
+impact, and available mitigations. Severity is assessed using CVSS when practical, tempered by the
+project's architecture: unauthorized downstream execution, credential exposure, grant replay, or
+an authorization bypass receives priority over availability-only defects.
+
+- **Critical:** practical compromise of the execution boundary or exposed privileged credentials
+  with broad impact.
+- **High:** authorization, integrity, or confidentiality failure requiring meaningful but realistic
+  prerequisites.
+- **Moderate:** limited security impact, strong prerequisites, or a substantial hardening gap.
+- **Low:** defense-in-depth or documentation issue with no demonstrated boundary bypass.
+
+If the report is valid, the security owner assigns a remediation owner, target release, disclosure
+coordinator, and next-update date. If severity is disputed, record both assessments and the final
+rationale privately.
+
+## Remediation and coordinated disclosure
+
+Develop the smallest complete fix on a private advisory fork. Add a regression test that contains
+no reusable exploit secret or real data, update the threat model and operator guidance, and run the
+normal verification and mutation gates for affected security-boundary code. Reviewers verify both
+the fix and whether temporary mitigations are truthful.
+
+Agree on a disclosure date with the reporter when practical. The advisory should identify affected
+and fixed versions, impact, prerequisites, mitigations, upgrade steps, credits, and any residual
+risk. Publish a patched release and signed verification artifacts before or with the advisory.
+Active exploitation, leaked credentials, or imminent user harm may require earlier mitigation or
+disclosure; record why coordination changed.
+
+Reporter credit is opt-in. Ask for the exact name and link to publish, offer anonymous credit, and
+honor a request for no credit. Never infer a reporter's identity from an email address or account
+name.
+
+## Special cases
+
+- **Duplicate:** link the private cases, tell the later reporter it is a duplicate without naming
+  the first reporter or disclosing embargoed details, and preserve each credit request for the
+  eventual advisory.
+- **Invalid or not reproducible:** explain the tested version, assumptions, and evidence briefly;
+  invite clarifying information; retain the private record; and do not publicly characterize the
+  reporter or report.
+- **End-of-life version:** test the latest supported release and explain the support policy. A flaw
+  that persists remains eligible for coordinated handling.
+- **Embargoed dependency or upstream issue:** follow the upstream embargo, restrict distribution,
+  prepare the repository change privately, and do not publish a revealing issue or commit before
+  the coordinated date.
+- **Report involving a maintainer:** recuse that person and follow the independent escalation path
+  in `CODE_OF_CONDUCT.md`.
+
+## Release and closure checklist
+
+- [ ] Private intake acknowledged and case owner assigned.
+- [ ] Reporter credit or anonymity preference recorded.
+- [ ] Affected and fixed versions, severity, and trust-boundary impact recorded.
+- [ ] Regression test, fix, threat-model update, and migration or mitigation guidance reviewed.
+- [ ] Full verification passed on the exact release commit.
+- [ ] Version and signed release artifacts published through the protected release workflow.
+- [ ] Advisory and release notes published on the coordinated date.
+- [ ] Reporter notified and public links checked.
+- [ ] Temporary branches, credentials, and private artifacts retired according to their owners'
+      retention rules.
+- [ ] Follow-up controls captured as issues without confidential details.
+
+## Tabletop exercise
+
+At least annually, and after a material response-process change, a maintainer runs this synthetic
+exercise without creating a real advisory or release:
+
+1. Start with a fictional report that a consumed grant can invoke the same synthetic handler twice.
+2. Walk the report through acknowledgement, severity, ownership, private-fix, release, credit, and
+   closure decisions using the checklist above.
+3. Add one duplicate report and one reporter requesting anonymity.
+4. Record only the date, participants or roles, steps exercised, gaps, and public follow-up issue
+   numbers in `SECURITY-EVIDENCE.md`; never record fictional secrets or imply a release occurred.
+
+An exercise passes only when every checklist owner and communication handoff is named, the release
+verification path can be located, and each gap has an accountable public follow-up or an explicit
+risk acceptance.

--- a/examples/basic-agent/src/Index.ts
+++ b/examples/basic-agent/src/Index.ts
@@ -27,7 +27,8 @@ const { authority, verifier } = createFixtureAuthorityPair(() => "BLOCK", {
 const registry = new ActionRegistry()
   .register("delete_customer", {
     parametersSchema: z.object({ customerId: z.string() }).strict(),
-    execute: ({ parameters }) => ({ deleted: parameters.customerId }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async () => ({ deleted: parameters.customerId })),
   })
   .seal();
 const decision = await authority.evaluate(captured);

--- a/examples/github-deploy-agent/src/Index.ts
+++ b/examples/github-deploy-agent/src/Index.ts
@@ -20,11 +20,13 @@ const registry = new ActionRegistry()
     parametersSchema: z
       .object({ environment: z.enum(["staging", "production"]), ref: z.string() })
       .strict(),
-    execute: ({ parameters }) => ({ dispatched: true, ...parameters }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async () => ({ dispatched: true, ...parameters })),
   })
   .register("force_push", {
     parametersSchema: z.object({ branch: z.string() }).strict(),
-    execute: ({ parameters }) => ({ pushed: parameters.branch }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async () => ({ pushed: parameters.branch })),
   })
   .seal();
 const executor = new SafeExecutor(registry, verifier);

--- a/examples/mcp-tool-gate/src/Index.ts
+++ b/examples/mcp-tool-gate/src/Index.ts
@@ -16,7 +16,8 @@ const { authority, verifier } = createFixtureAuthorityPair(() => "BLOCK", {
 const registry = new ActionRegistry()
   .register("delete_customer", {
     parametersSchema: z.object({ customerId: z.string().min(1).max(120) }).strict(),
-    execute: ({ parameters }) => ({ deleted: parameters.customerId }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async () => ({ deleted: parameters.customerId })),
   })
   .seal();
 const executor = new SafeExecutor(registry, verifier);

--- a/examples/procurement-agent/src/Index.ts
+++ b/examples/procurement-agent/src/Index.ts
@@ -63,11 +63,12 @@ const registry = new ActionRegistry()
         requestedConcurrentUsers: z.number().int().positive(),
       })
       .strict(),
-    execute: ({ parameters }) => ({
-      purchaseOrderCreated: true,
-      productId: parameters.productId,
-      amountMinor: parameters.amountMinor,
-    }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async () => ({
+        purchaseOrderCreated: true,
+        productId: parameters.productId,
+        amountMinor: parameters.amountMinor,
+      })),
   })
   .seal();
 

--- a/examples/shopify-refund-agent/src/Index.ts
+++ b/examples/shopify-refund-agent/src/Index.ts
@@ -63,13 +63,14 @@ const registry = new ActionRegistry()
         orderId: z.string(),
       })
       .strict(),
-    execute: ({ parameters, authorization }) => ({
-      providerRequest: {
-        orderId: parameters.orderId,
-        amountMinor: parameters.amountMinor,
-        idempotencyKey: authorization.grantId,
-      },
-    }),
+    execute: async ({ parameters, dispatch }) =>
+      await dispatch.run(async (idempotencyKey) => ({
+        providerRequest: {
+          orderId: parameters.orderId,
+          amountMinor: parameters.amountMinor,
+          idempotencyKey,
+        },
+      })),
   })
   .seal();
 const result = await new SafeExecutor(registry, verifier).run(captured, decision);

--- a/fixtures/manifest.json
+++ b/fixtures/manifest.json
@@ -123,6 +123,12 @@
       "containsCustomerData": false
     },
     {
+      "path": "packages/pipeline/test/audit/AuditRecorder.test.ts",
+      "family": "Unit-test fixture",
+      "source": "synthetic",
+      "containsCustomerData": false
+    },
+    {
       "path": "packages/pipeline/test/decision/DecionisGate.test.ts",
       "family": "Unit-test fixture",
       "source": "synthetic",

--- a/packages/pipeline/src/Index.ts
+++ b/packages/pipeline/src/Index.ts
@@ -1,4 +1,5 @@
 export * from "./approval/PresenceApprovalCoordinator.js";
+export * from "./audit/AuditRecorder.js";
 export * from "./decision/DecisionAuthority.js";
 export * from "./decision/DecionisGate.js";
 export * from "./decision/FixtureDecisionAuthority.js";

--- a/packages/pipeline/src/approval/PresenceApprovalCoordinator.ts
+++ b/packages/pipeline/src/approval/PresenceApprovalCoordinator.ts
@@ -1,4 +1,5 @@
 import type { GateResult, HumanApprovalGate } from "@decionis/presence-node";
+import type { AuditRecorder } from "../audit/AuditRecorder.js";
 import type {
   DecisionAuthority,
   GateDecision,
@@ -11,6 +12,8 @@ export type PresenceGateResult = GateResult;
 export type PresenceApprovalClient = Pick<HumanApprovalGate, "gate" | "outcome">;
 
 export interface PresenceApprovalCoordinatorOptions {
+  /** Optional bounded lifecycle audit recorder. */
+  readonly audit?: AuditRecorder;
   /** Maximum number of outcome lookups after Presence returns HUMAN_REQUIRED. */
   readonly maxAttempts?: number;
   /** Initial exponential-backoff delay in milliseconds. */
@@ -65,6 +68,7 @@ const MAX_DEADLINE_LIMIT_MS = 300_000;
  */
 export class PresenceApprovalCoordinator {
   private readonly polling: PollingConfiguration;
+  private readonly audit: AuditRecorder | undefined;
 
   public constructor(
     private readonly presence: PresenceApprovalClient,
@@ -74,6 +78,7 @@ export class PresenceApprovalCoordinator {
     options: PresenceApprovalCoordinatorOptions = {},
   ) {
     this.polling = PresenceApprovalCoordinator.pollingConfiguration(options);
+    this.audit = options.audit;
   }
 
   public async request(captured: CapturedIntent): Promise<PresenceGateResult> {
@@ -110,6 +115,11 @@ export class PresenceApprovalCoordinator {
         throw new Error("Presence returned an invalid gate response");
       }
 
+      await this.recordPresence(
+        captured,
+        verdict === "HUMAN_REQUIRED" ? "PRESENCE_ESCALATED" : "PRESENCE_RESOLVED",
+        verdict,
+      );
       return result;
     } catch {
       throw new Error("PRESENCE_REQUEST_FAILED");
@@ -137,6 +147,7 @@ export class PresenceApprovalCoordinator {
     }
 
     if (verdict !== "PROCEED") {
+      await this.recordPresence(captured, "PRESENCE_RESOLVED", verdict);
       return FailClosedDecision.create(captured.intentHash, `PRESENCE_${verdict}`);
     }
 
@@ -144,6 +155,8 @@ export class PresenceApprovalCoordinator {
     if (evidence === null) {
       return FailClosedDecision.create(captured.intentHash, "PRESENCE_PROOF_MISSING");
     }
+
+    await this.recordPresence(captured, "PRESENCE_RESOLVED", verdict, evidence.receiptDossierId);
 
     const preAuthorizationFailure = this.boundaryFailure(captured, options.signal);
     if (preAuthorizationFailure !== null) {
@@ -393,6 +406,21 @@ export class PresenceApprovalCoordinator {
 
   private boundedIdentifier(value: unknown): value is string {
     return typeof value === "string" && value.length > 0 && value.length <= 200;
+  }
+
+  private async recordPresence(
+    captured: CapturedIntent,
+    eventType: "PRESENCE_ESCALATED" | "PRESENCE_RESOLVED",
+    verdict: "PROCEED" | "HUMAN_REQUIRED" | "DENIED" | "ESCALATED",
+    dossierId?: string,
+  ): Promise<void> {
+    await this.audit?.record({
+      eventType,
+      captured,
+      authority: "NON_AUTHORITATIVE",
+      ...(dossierId === undefined ? {} : { dossierId }),
+      reasonCodes: [`PRESENCE_${verdict}`],
+    });
   }
 
   private isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/pipeline/src/audit/AuditRecorder.ts
+++ b/packages/pipeline/src/audit/AuditRecorder.ts
@@ -1,0 +1,423 @@
+import { randomUUID } from "node:crypto";
+import type { GateDecision } from "../decision/DecisionAuthority.js";
+import type { CapturedIntent } from "../intent/ExecutionIntent.js";
+import type { JsonObject, JsonValue } from "../intent/JsonValue.js";
+import type { VerifiedAuthorization } from "../execution/AuthorizationVerifier.js";
+
+export type AuditEventType =
+  | "INTENT_CAPTURED"
+  | "AUTHORITY_DECISION"
+  | "AUTHORITY_FAILED_CLOSED"
+  | "PRESENCE_ESCALATED"
+  | "PRESENCE_RESOLVED"
+  | "GRANT_CONSUMED"
+  | "EXECUTION_STARTED"
+  | "EXECUTION_COMPLETED"
+  | "EXECUTION_BLOCKED"
+  | "EXECUTION_FAILED_BEFORE_DISPATCH"
+  | "EXECUTION_OUTCOME_UNKNOWN"
+  | "RECONCILIATION_COMPLETED"
+  | "RECONCILIATION_NOT_EXECUTED"
+  | "RECONCILIATION_UNKNOWN";
+
+export type AuditAuthority = "AUTHORITATIVE" | "OBSERVATIONAL" | "NON_AUTHORITATIVE";
+
+export interface AuditPolicyRevision {
+  readonly policyId: string;
+  readonly revisionId: string;
+  readonly version?: string;
+  readonly digest: `sha256:${string}`;
+}
+
+export interface AuditEvaluationEvidence {
+  readonly evaluationId?: string;
+  readonly materialInputDigest?: `sha256:${string}`;
+  readonly policy?: AuditPolicyRevision;
+  readonly evidenceReference?: string;
+}
+
+export interface AuditEventV1 {
+  readonly schemaVersion: "agent-safe.audit/1";
+  readonly eventId: string;
+  readonly occurredAt: string;
+  readonly eventType: AuditEventType;
+  readonly authority: AuditAuthority;
+  readonly correlation: {
+    readonly intentId: string;
+    readonly intentHash: string;
+    readonly correlationId?: string;
+    readonly decisionId?: string;
+    readonly dossierId?: string;
+    readonly grantId?: string;
+  };
+  readonly evaluation: {
+    readonly evaluationId: string;
+    readonly materialInputDigest: string;
+    readonly policy: AuditPolicyRevision | null;
+    readonly evidenceReference: string | null;
+  } | null;
+  readonly verdict: GateDecision["verdict"] | null;
+  readonly reasonCodes: readonly string[];
+  readonly durationMs: number | null;
+  readonly metadata: Readonly<JsonObject>;
+}
+
+export interface AuditSink {
+  write(event: AuditEventV1): Promise<void> | void;
+}
+
+export interface AuditRecordInput {
+  readonly eventType: AuditEventType;
+  readonly captured: CapturedIntent;
+  readonly authority?: AuditAuthority;
+  readonly decision?: GateDecision;
+  readonly authorization?: VerifiedAuthorization;
+  readonly decisionId?: string;
+  readonly dossierId?: string;
+  readonly grantId?: string;
+  readonly evaluation?: AuditEvaluationEvidence;
+  readonly reasonCodes?: readonly string[];
+  readonly durationMs?: number;
+  readonly metadata?: Readonly<Record<string, JsonValue>>;
+}
+
+export interface AuditRecorderOptions {
+  readonly sink: AuditSink;
+  readonly timeoutMs?: number;
+  readonly failurePolicy?: "BEST_EFFORT" | "REQUIRE_BEFORE_EXECUTION";
+  readonly metadataAllowlist?: readonly string[];
+  readonly redactMetadata?: (key: string, value: JsonValue) => JsonValue | undefined;
+  readonly clock?: () => Date;
+  readonly createId?: () => string;
+}
+
+export interface AuditPolicyRevisionArtifact extends AuditPolicyRevision {
+  /** Opaque location or object-store version used by an authorized replay system. */
+  readonly artifactReference: string;
+}
+
+export interface AuditPolicyRevisionResolver {
+  resolve(
+    policyId: string,
+    revisionId: string,
+  ): Promise<AuditPolicyRevisionArtifact | null> | AuditPolicyRevisionArtifact | null;
+}
+
+export type AuditPolicyVerification =
+  | { readonly status: "VERIFIED"; readonly artifact: AuditPolicyRevisionArtifact }
+  | { readonly status: "NOT_REFERENCED"; readonly artifact: null }
+  | {
+      readonly status: "MISSING" | "DIGEST_MISMATCH" | "IDENTITY_MISMATCH" | "UNAVAILABLE";
+      readonly artifact: null;
+    };
+
+const DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+const AUDIT_AUTHORITIES = new Set<AuditAuthority>([
+  "AUTHORITATIVE",
+  "OBSERVATIONAL",
+  "NON_AUTHORITATIVE",
+]);
+const RESTRICTED_METADATA_KEY =
+  /authorization|credential|password|secret|token|parameters|context|provider[_-]?result/i;
+const MAX_METADATA_DEPTH = 4;
+const MAX_METADATA_ENTRIES = 50;
+const MAX_METADATA_ARRAY = 20;
+const MAX_METADATA_STRING = 500;
+const MAX_METADATA_BYTES = 4 * 1024;
+
+/**
+ * Emits immutable, redacted lifecycle records through one bounded sink call.
+ * Sink failures are converted to `false`; the recorder never retries because
+ * retries could reorder evidence or couple provider execution to sink health.
+ */
+export class AuditRecorder {
+  private readonly timeoutMs: number;
+  private readonly failurePolicy: "BEST_EFFORT" | "REQUIRE_BEFORE_EXECUTION";
+  private readonly metadataAllowlist: ReadonlySet<string>;
+  private readonly clock: () => Date;
+  private readonly createId: () => string;
+
+  public constructor(private readonly options: AuditRecorderOptions) {
+    this.timeoutMs = Math.min(Math.max(options.timeoutMs ?? 100, 1), 5_000);
+    this.failurePolicy = options.failurePolicy ?? "BEST_EFFORT";
+    this.metadataAllowlist = new Set(options.metadataAllowlist ?? []);
+    this.clock = options.clock ?? (() => new Date());
+    this.createId = options.createId ?? randomUUID;
+    if (this.metadataAllowlist.size > MAX_METADATA_ENTRIES) {
+      throw new Error("AUDIT_METADATA_ALLOWLIST_TOO_LARGE");
+    }
+    for (const key of this.metadataAllowlist) AuditRecorder.assertIdentifier(key);
+  }
+
+  public get requiresDeliveryBeforeExecution(): boolean {
+    return this.failurePolicy === "REQUIRE_BEFORE_EXECUTION";
+  }
+
+  public async record(input: AuditRecordInput): Promise<boolean> {
+    try {
+      const event = this.event(input);
+      const delivered = await new Promise<boolean>((resolve) => {
+        let settled = false;
+        const settle = (result: boolean): void => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolve(result);
+        };
+        const timeout = setTimeout(() => settle(false), this.timeoutMs);
+        void Promise.resolve()
+          .then(async () => await this.options.sink.write(event))
+          .then(
+            () => settle(true),
+            () => settle(false),
+          );
+      });
+      return delivered;
+    } catch {
+      return false;
+    }
+  }
+
+  private event(input: AuditRecordInput): AuditEventV1 {
+    AuditRecorder.assertIdentifier(input.captured.intent.intentId);
+    AuditRecorder.assertDigest(input.captured.intentHash);
+    if (
+      input.durationMs !== undefined &&
+      (!Number.isFinite(input.durationMs) || input.durationMs < 0)
+    ) {
+      throw new Error("AUDIT_DURATION_INVALID");
+    }
+    const reasonCodes = input.reasonCodes ?? input.decision?.reasonCodes ?? [];
+    if (reasonCodes.length > 50) throw new Error("AUDIT_REASON_CODES_TOO_MANY");
+    for (const reasonCode of reasonCodes) {
+      AuditRecorder.assertIdentifier(reasonCode);
+    }
+    const authority = input.authority ?? AuditRecorder.defaultAuthority(input.eventType);
+    if (!AUDIT_AUTHORITIES.has(authority)) throw new Error("AUDIT_AUTHORITY_INVALID");
+
+    const decisionId = input.decisionId ?? input.decision?.decisionId;
+    const dossierId = input.dossierId ?? input.decision?.dossierId ?? undefined;
+    const grantId = input.grantId ?? input.authorization?.grantId;
+    if (decisionId !== undefined) AuditRecorder.assertIdentifier(decisionId);
+    if (dossierId !== undefined) AuditRecorder.assertIdentifier(dossierId);
+    if (grantId !== undefined) AuditRecorder.assertIdentifier(grantId);
+    if (input.captured.intent.correlationId !== undefined) {
+      AuditRecorder.assertIdentifier(input.captured.intent.correlationId);
+    }
+
+    const evaluation = input.decision
+      ? this.evaluation(input.captured, input.decision, input.evaluation)
+      : null;
+    const event: AuditEventV1 = {
+      schemaVersion: "agent-safe.audit/1",
+      eventId: this.boundedId(this.createId()),
+      occurredAt: this.validDate(this.clock()).toISOString(),
+      eventType: input.eventType,
+      authority,
+      correlation: {
+        intentId: input.captured.intent.intentId,
+        intentHash: input.captured.intentHash,
+        ...(input.captured.intent.correlationId === undefined
+          ? {}
+          : { correlationId: input.captured.intent.correlationId }),
+        ...(decisionId === undefined ? {} : { decisionId }),
+        ...(dossierId === undefined ? {} : { dossierId }),
+        ...(grantId === undefined ? {} : { grantId }),
+      },
+      evaluation,
+      verdict: input.decision?.verdict ?? null,
+      reasonCodes: [...reasonCodes],
+      durationMs:
+        input.durationMs === undefined ? null : Math.round(input.durationMs * 1_000) / 1_000,
+      metadata: this.metadata(input.metadata),
+    };
+    return AuditRecorder.deepFreeze(event);
+  }
+
+  private evaluation(
+    captured: CapturedIntent,
+    decision: GateDecision,
+    evidence?: AuditEvaluationEvidence,
+  ): NonNullable<AuditEventV1["evaluation"]> {
+    const evaluationId = evidence?.evaluationId ?? decision.decisionId;
+    const materialInputDigest = evidence?.materialInputDigest ?? captured.intentHash;
+    const evidenceReference = evidence?.evidenceReference ?? decision.dossierId;
+    AuditRecorder.assertIdentifier(evaluationId);
+    AuditRecorder.assertDigest(materialInputDigest);
+    if (evidenceReference !== null) AuditRecorder.assertIdentifier(evidenceReference);
+
+    let policy: AuditPolicyRevision | null = null;
+    if (evidence?.policy !== undefined) {
+      AuditRecorder.assertIdentifier(evidence.policy.policyId);
+      AuditRecorder.assertIdentifier(evidence.policy.revisionId);
+      if (/^(?:current|latest)$/i.test(evidence.policy.revisionId)) {
+        throw new Error("AUDIT_POLICY_REVISION_MUTABLE_ALIAS");
+      }
+      if (evidence.policy.version !== undefined) {
+        AuditRecorder.assertIdentifier(evidence.policy.version);
+      }
+      AuditRecorder.assertDigest(evidence.policy.digest);
+      policy = { ...evidence.policy };
+    }
+    return {
+      evaluationId,
+      materialInputDigest,
+      policy,
+      evidenceReference,
+    };
+  }
+
+  private metadata(input?: Readonly<Record<string, JsonValue>>): Readonly<JsonObject> {
+    if (input === undefined) return Object.freeze({});
+    const output: JsonObject = {};
+    for (const [key, value] of Object.entries(input)) {
+      if (!this.metadataAllowlist.has(key) || RESTRICTED_METADATA_KEY.test(key)) continue;
+      const redacted =
+        this.options.redactMetadata === undefined ? value : this.options.redactMetadata(key, value);
+      if (redacted !== undefined) output[key] = this.copyJson(redacted, 0, { entries: 0 });
+    }
+    if (Buffer.byteLength(JSON.stringify(output), "utf8") > MAX_METADATA_BYTES) {
+      throw new Error("AUDIT_METADATA_TOO_LARGE");
+    }
+    return AuditRecorder.deepFreeze(output);
+  }
+
+  private copyJson(value: JsonValue, depth: number, count: { entries: number }): JsonValue {
+    if (depth > MAX_METADATA_DEPTH) throw new Error("AUDIT_METADATA_TOO_DEEP");
+    if (typeof value === "string") {
+      if (value.length > MAX_METADATA_STRING) throw new Error("AUDIT_METADATA_STRING_TOO_LONG");
+      return value;
+    }
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      throw new Error("AUDIT_METADATA_NUMBER_INVALID");
+    }
+    if (value === null || typeof value !== "object") return value;
+    if (Array.isArray(value)) {
+      if (value.length > MAX_METADATA_ARRAY) throw new Error("AUDIT_METADATA_ARRAY_TOO_LONG");
+      return value.map((entry) => {
+        count.entries += 1;
+        if (count.entries > MAX_METADATA_ENTRIES) throw new Error("AUDIT_METADATA_TOO_COMPLEX");
+        return this.copyJson(entry, depth + 1, count);
+      });
+    }
+    const prototype = Object.getPrototypeOf(value) as unknown;
+    if (prototype !== Object.prototype && prototype !== null) {
+      throw new Error("AUDIT_METADATA_OBJECT_INVALID");
+    }
+    const copy: JsonObject = {};
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === "__proto__" || key === "constructor" || key === "prototype") {
+        throw new Error("AUDIT_METADATA_KEY_INVALID");
+      }
+      count.entries += 1;
+      if (count.entries > MAX_METADATA_ENTRIES) throw new Error("AUDIT_METADATA_TOO_COMPLEX");
+      copy[key] = this.copyJson(entry, depth + 1, count);
+    }
+    return copy;
+  }
+
+  private boundedId(value: string): string {
+    AuditRecorder.assertIdentifier(value);
+    return value;
+  }
+
+  private validDate(value: Date): Date {
+    if (!(value instanceof Date) || !Number.isFinite(value.valueOf())) {
+      throw new Error("AUDIT_CLOCK_INVALID");
+    }
+    return value;
+  }
+
+  private static defaultAuthority(eventType: AuditEventType): AuditAuthority {
+    if (eventType === "INTENT_CAPTURED") return "NON_AUTHORITATIVE";
+    if (eventType === "PRESENCE_ESCALATED" || eventType === "PRESENCE_RESOLVED") {
+      return "NON_AUTHORITATIVE";
+    }
+    return "AUTHORITATIVE";
+  }
+
+  private static assertIdentifier(value: string): void {
+    if (!isBoundedIdentifier(value)) throw new Error("AUDIT_IDENTIFIER_INVALID");
+  }
+
+  private static assertDigest(value: string): asserts value is `sha256:${string}` {
+    if (!DIGEST_PATTERN.test(value)) throw new Error("AUDIT_DIGEST_INVALID");
+  }
+
+  private static deepFreeze<T>(value: T): T {
+    if (typeof value === "object" && value !== null && !Object.isFrozen(value)) {
+      Object.freeze(value);
+      for (const child of Object.values(value as Record<string, unknown>)) {
+        AuditRecorder.deepFreeze(child);
+      }
+    }
+    return value;
+  }
+}
+
+/** Resolves historical policy evidence by its pinned revision, never by a mutable alias. */
+export class AuditPolicyRevisionVerifier {
+  private readonly timeoutMs: number;
+
+  public constructor(
+    private readonly resolver: AuditPolicyRevisionResolver,
+    timeoutMs = 1_000,
+  ) {
+    this.timeoutMs = Math.min(Math.max(timeoutMs, 1), 15_000);
+  }
+
+  public async verify(event: AuditEventV1): Promise<AuditPolicyVerification> {
+    const reference = event.evaluation?.policy;
+    if (reference === null || reference === undefined) {
+      return { status: "NOT_REFERENCED", artifact: null };
+    }
+
+    const resolved = await new Promise<AuditPolicyRevisionArtifact | null | undefined>(
+      (resolve) => {
+        let settled = false;
+        const settle = (value: AuditPolicyRevisionArtifact | null | undefined): void => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolve(value);
+        };
+        const timeout = setTimeout(() => settle(undefined), this.timeoutMs);
+        void Promise.resolve()
+          .then(async () => await this.resolver.resolve(reference.policyId, reference.revisionId))
+          .then(
+            (artifact) => settle(artifact),
+            () => settle(undefined),
+          );
+      },
+    );
+    if (resolved === undefined) return { status: "UNAVAILABLE", artifact: null };
+    if (resolved === null) return { status: "MISSING", artifact: null };
+    if (resolved.policyId !== reference.policyId || resolved.revisionId !== reference.revisionId) {
+      return { status: "IDENTITY_MISMATCH", artifact: null };
+    }
+    if (resolved.digest !== reference.digest) {
+      return { status: "DIGEST_MISMATCH", artifact: null };
+    }
+    if (
+      !isBoundedIdentifier(resolved.artifactReference) ||
+      !isBoundedIdentifier(resolved.policyId) ||
+      !isBoundedIdentifier(resolved.revisionId) ||
+      !DIGEST_PATTERN.test(resolved.digest)
+    ) {
+      return { status: "UNAVAILABLE", artifact: null };
+    }
+    return {
+      status: "VERIFIED",
+      artifact: Object.freeze({ ...resolved }),
+    };
+  }
+}
+
+function isBoundedIdentifier(value: string): boolean {
+  if (value.length < 1 || value.length > 200) return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const codeUnit = value.charCodeAt(index);
+    if (codeUnit <= 0x1f || codeUnit === 0x7f) return false;
+  }
+  return true;
+}

--- a/packages/pipeline/src/execution/ActionRegistry.ts
+++ b/packages/pipeline/src/execution/ActionRegistry.ts
@@ -6,20 +6,58 @@ export interface ActionExecutionContext<TParameters> {
   readonly intent: CapturedIntent;
   readonly parameters: TParameters;
   readonly authorization: VerifiedAuthorization;
+  /**
+   * Trusted handlers must place the provider side effect inside `dispatch.run`.
+   * This records the point after which a transport error has an unknown outcome
+   * and exposes only the intent-bound idempotency key, never an execution token.
+   */
+  readonly dispatch: ProviderDispatch;
 }
+
+export interface ProviderDispatch {
+  readonly idempotencyKey: string;
+  run<TResult>(operation: (idempotencyKey: string) => Promise<TResult> | TResult): Promise<TResult>;
+}
+
+export interface ActionReconciliationContext<TParameters> {
+  readonly intent: CapturedIntent;
+  readonly parameters: TParameters;
+  readonly idempotencyKey: string;
+}
+
+export type ProviderReconciliation<TResult> =
+  | { readonly status: "COMPLETED"; readonly result: TResult }
+  | { readonly status: "NOT_EXECUTED" }
+  | { readonly status: "UNKNOWN" };
 
 export interface ActionHandler<TParameters, TResult> {
   readonly parametersSchema: z.ZodType<TParameters>;
   execute(context: ActionExecutionContext<TParameters>): Promise<TResult> | TResult;
+  /** Read-only provider lookup. It must never initiate or retry a side effect. */
+  reconcile?(
+    context: ActionReconciliationContext<TParameters>,
+  ): Promise<ProviderReconciliation<TResult>> | ProviderReconciliation<TResult>;
 }
 
 interface RegisteredAction {
   readonly parametersSchema: z.ZodType<unknown>;
   execute(context: ActionExecutionContext<unknown>): Promise<unknown> | unknown;
+  reconcile?(
+    context: ActionReconciliationContext<unknown>,
+  ): Promise<ProviderReconciliation<unknown>> | ProviderReconciliation<unknown>;
 }
+
+export type ActionExecutionAttempt =
+  | { readonly status: "COMPLETED"; readonly result: unknown }
+  | { readonly status: "FAILED_BEFORE_DISPATCH" }
+  | { readonly status: "UNKNOWN_AFTER_DISPATCH" };
 
 export class ActionRegistry {
   private readonly actions = new Map<string, RegisteredAction>();
+  private readonly pendingReconciliations = new Map<
+    string,
+    Promise<ProviderReconciliation<unknown>>
+  >();
   private sealed = false;
 
   public register<TParameters, TResult>(
@@ -54,11 +92,96 @@ export class ActionRegistry {
     captured: CapturedIntent,
     authorization: VerifiedAuthorization,
   ): Promise<unknown> {
+    const attempt = await this.executeTracked(captured, authorization);
+    if (attempt.status === "COMPLETED") return attempt.result;
+    throw new Error(attempt.status);
+  }
+
+  public async executeTracked(
+    captured: CapturedIntent,
+    authorization: VerifiedAuthorization,
+  ): Promise<ActionExecutionAttempt> {
     if (!this.sealed) throw new Error("ACTION_REGISTRY_NOT_SEALED");
     const handler = this.actions.get(captured.intent.action);
     if (!handler) throw new Error("ACTION_NOT_REGISTERED");
     const result = handler.parametersSchema.safeParse(captured.intent.parameters);
     if (!result.success) throw new Error("ACTION_PARAMETERS_INVALID");
-    return handler.execute({ intent: captured, parameters: result.data, authorization });
+    let dispatched = false;
+    const dispatch: ProviderDispatch = Object.freeze({
+      idempotencyKey: captured.intent.idempotencyKey,
+      run: async <TResult>(
+        operation: (idempotencyKey: string) => Promise<TResult> | TResult,
+      ): Promise<TResult> => {
+        if (dispatched) throw new Error("PROVIDER_DISPATCH_ALREADY_STARTED");
+        dispatched = true;
+        return await operation(captured.intent.idempotencyKey);
+      },
+    });
+
+    try {
+      return {
+        status: "COMPLETED",
+        result: await handler.execute({
+          intent: captured,
+          parameters: result.data,
+          authorization,
+          dispatch,
+        }),
+      };
+    } catch {
+      return { status: dispatched ? "UNKNOWN_AFTER_DISPATCH" : "FAILED_BEFORE_DISPATCH" };
+    }
+  }
+
+  public async reconcile(
+    captured: CapturedIntent,
+    idempotencyKey: string,
+  ): Promise<ProviderReconciliation<unknown>> {
+    if (!this.sealed) throw new Error("ACTION_REGISTRY_NOT_SEALED");
+    if (idempotencyKey !== captured.intent.idempotencyKey) {
+      throw new Error("RECONCILIATION_BINDING_MISMATCH");
+    }
+    const handler = this.actions.get(captured.intent.action);
+    if (!handler) throw new Error("ACTION_NOT_REGISTERED");
+    const parameters = handler.parametersSchema.safeParse(captured.intent.parameters);
+    if (!parameters.success) throw new Error("ACTION_PARAMETERS_INVALID");
+    if (handler.reconcile === undefined) return { status: "UNKNOWN" };
+
+    const key = `${captured.intentHash}\u0000${idempotencyKey}`;
+    const pending = this.pendingReconciliations.get(key);
+    if (pending !== undefined) return await pending;
+
+    const reconciliation = Promise.resolve()
+      .then(async () =>
+        this.validReconciliation(
+          await handler.reconcile?.({
+            intent: captured,
+            parameters: parameters.data,
+            idempotencyKey,
+          }),
+        ),
+      )
+      .catch((): ProviderReconciliation<unknown> => ({ status: "UNKNOWN" }))
+      .finally(() => this.pendingReconciliations.delete(key));
+    this.pendingReconciliations.set(key, reconciliation);
+    return await reconciliation;
+  }
+
+  private validReconciliation(value: unknown): ProviderReconciliation<unknown> {
+    if (typeof value !== "object" || value === null || Array.isArray(value)) {
+      return { status: "UNKNOWN" };
+    }
+    const record = value as Record<string, unknown>;
+    const keys = Object.keys(record);
+    if (record["status"] === "COMPLETED" && keys.length === 2 && "result" in record) {
+      return { status: "COMPLETED", result: record["result"] };
+    }
+    if (
+      (record["status"] === "NOT_EXECUTED" || record["status"] === "UNKNOWN") &&
+      keys.length === 1
+    ) {
+      return { status: record["status"] };
+    }
+    return { status: "UNKNOWN" };
   }
 }

--- a/packages/pipeline/src/execution/SafeExecutor.ts
+++ b/packages/pipeline/src/execution/SafeExecutor.ts
@@ -1,4 +1,5 @@
 import type { GateDecision } from "../decision/DecisionAuthority.js";
+import type { AuditEventType, AuditRecorder } from "../audit/AuditRecorder.js";
 import { CanonicalIntentHasher } from "../intent/CanonicalIntentHasher.js";
 import type { CapturedIntent } from "../intent/ExecutionIntent.js";
 import type { ActionRegistry } from "./ActionRegistry.js";
@@ -9,20 +10,69 @@ export type ExecutionBlockReason =
   | "INTENT_BINDING_MISMATCH"
   | "INTENT_CONFORMANCE_FAILED"
   | "AUTHORIZATION_MISSING"
-  | "AUTHORIZATION_INVALID";
+  | "AUTHORIZATION_INVALID"
+  | "RECOVERY_BINDING_MISMATCH"
+  | "AUDIT_UNAVAILABLE";
+
+export type ExecutionPreDispatchFailureReason =
+  "HANDLER_FAILED_BEFORE_DISPATCH" | "AUDIT_UNAVAILABLE";
+
+export interface ExecutionRecoveryReference extends VerifiedAuthorization {
+  readonly version: "agent-safe.recovery/1";
+  readonly idempotencyKey: string;
+}
+
+export interface ExecutionBlockedResult {
+  readonly outcome: "BLOCKED";
+  readonly executed: false;
+  readonly reason: ExecutionBlockReason;
+  readonly result: null;
+  readonly authorization: null;
+}
 
 export type SafeExecutionResult<TResult = unknown> =
   | {
+      readonly outcome: "COMPLETED";
       readonly executed: true;
+      readonly recovered: false;
+      readonly result: TResult;
+      readonly authorization: VerifiedAuthorization;
+    }
+  | ExecutionBlockedResult
+  | {
+      readonly outcome: "FAILED_BEFORE_DISPATCH";
+      readonly executed: false;
+      readonly reason: ExecutionPreDispatchFailureReason;
+      readonly result: null;
+      readonly authorization: VerifiedAuthorization;
+    }
+  | {
+      readonly outcome: "UNKNOWN_AFTER_DISPATCH";
+      readonly executed: null;
+      readonly reason: "PROVIDER_OUTCOME_UNKNOWN";
+      readonly result: null;
+      readonly authorization: VerifiedAuthorization;
+      readonly recovery: ExecutionRecoveryReference;
+    };
+
+export type ExecutionReconciliationResult<TResult = unknown> =
+  | {
+      readonly outcome: "COMPLETED";
+      readonly executed: true;
+      readonly recovered: true;
       readonly result: TResult;
       readonly authorization: VerifiedAuthorization;
     }
   | {
+      readonly outcome: "DEFINITELY_NOT_EXECUTED";
       readonly executed: false;
-      readonly reason: ExecutionBlockReason;
+      readonly recovered: true;
+      readonly reason: "PROVIDER_CONFIRMED_NOT_EXECUTED";
       readonly result: null;
-      readonly authorization: null;
-    };
+      readonly authorization: VerifiedAuthorization;
+    }
+  | ExecutionBlockedResult
+  | Extract<SafeExecutionResult<never>, { readonly outcome: "UNKNOWN_AFTER_DISPATCH" }>;
 
 export class SafeExecutor {
   private readonly hasher = new CanonicalIntentHasher();
@@ -30,32 +80,51 @@ export class SafeExecutor {
   public constructor(
     private readonly registry: ActionRegistry,
     private readonly verifier: AuthorizationVerifier,
+    private readonly audit?: AuditRecorder,
   ) {}
 
   public async run<TResult = unknown>(
     captured: CapturedIntent,
     decision: GateDecision,
   ): Promise<SafeExecutionResult<TResult>> {
+    const startedAt = Date.now();
+    // Stryker disable next-line all: Audit payload mapping is covered by lifecycle event assertions.
+    const intentRecorded = await this.record({ eventType: "INTENT_CAPTURED", captured });
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    const decisionRecorded = await this.record({
+      eventType: decision.failClosed ? "AUTHORITY_FAILED_CLOSED" : "AUTHORITY_DECISION",
+      captured,
+      decision,
+    });
+    // Stryker restore all
+    if (
+      this.audit?.requiresDeliveryBeforeExecution === true &&
+      (!intentRecorded || !decisionRecorded)
+    ) {
+      return await this.block(captured, decision, "AUDIT_UNAVAILABLE", startedAt);
+    }
     if (decision.verdict !== "ALLOW" || decision.failClosed) {
-      return SafeExecutor.blocked("DECISION_NOT_ALLOW");
+      return await this.block(captured, decision, "DECISION_NOT_ALLOW", startedAt);
     }
     if (decision.intentHash !== captured.intentHash) {
-      return SafeExecutor.blocked("INTENT_BINDING_MISMATCH");
+      return await this.block(captured, decision, "INTENT_BINDING_MISMATCH", startedAt);
     }
     if (decision.authorization === null) {
-      return SafeExecutor.blocked("AUTHORIZATION_MISSING");
+      return await this.block(captured, decision, "AUTHORIZATION_MISSING", startedAt);
     }
     if (!this.intentConforms(captured)) {
-      return SafeExecutor.blocked("INTENT_CONFORMANCE_FAILED");
+      return await this.block(captured, decision, "INTENT_CONFORMANCE_FAILED", startedAt);
     }
     this.registry.validate(captured);
     let authorization: VerifiedAuthorization | null;
     try {
       authorization = await this.verifier.verifyAndConsume(captured, decision);
     } catch {
-      return SafeExecutor.blocked("AUTHORIZATION_INVALID");
+      return await this.block(captured, decision, "AUTHORIZATION_INVALID", startedAt);
     }
-    if (authorization === null) return SafeExecutor.blocked("AUTHORIZATION_INVALID");
+    if (authorization === null) {
+      return await this.block(captured, decision, "AUTHORIZATION_INVALID", startedAt);
+    }
     const authorizationExpiry = Date.parse(authorization.expiresAt);
     if (
       authorization.decisionId !== decision.decisionId ||
@@ -67,18 +136,169 @@ export class SafeExecutor {
       authorizationExpiry <= Date.now() ||
       authorizationExpiry > Date.parse(captured.intent.expiresAt)
     ) {
-      return SafeExecutor.blocked("AUTHORIZATION_INVALID");
+      return await this.block(captured, decision, "AUTHORIZATION_INVALID", startedAt);
     }
     if (!this.intentConforms(captured)) {
-      return SafeExecutor.blocked("INTENT_CONFORMANCE_FAILED");
+      return await this.block(captured, decision, "INTENT_CONFORMANCE_FAILED", startedAt);
     }
-    let result: TResult;
-    try {
-      result = (await this.registry.execute(captured, authorization)) as TResult;
-    } catch {
-      throw new Error("ACTION_EXECUTION_FAILED");
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    const grantRecorded = await this.record({
+      eventType: "GRANT_CONSUMED",
+      captured,
+      decision,
+      authorization,
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    if (this.audit?.requiresDeliveryBeforeExecution === true && !grantRecorded) {
+      return await this.failedBeforeDispatch(
+        captured,
+        decision,
+        authorization,
+        "AUDIT_UNAVAILABLE",
+        startedAt,
+      );
     }
-    return { executed: true, result, authorization };
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    const executionRecorded = await this.record({
+      eventType: "EXECUTION_STARTED",
+      captured,
+      decision,
+      authorization,
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    if (this.audit?.requiresDeliveryBeforeExecution === true && !executionRecorded) {
+      return await this.failedBeforeDispatch(
+        captured,
+        decision,
+        authorization,
+        "AUDIT_UNAVAILABLE",
+        startedAt,
+      );
+    }
+    const attempt = await this.registry.executeTracked(captured, authorization);
+    if (attempt.status === "FAILED_BEFORE_DISPATCH") {
+      return await this.failedBeforeDispatch(
+        captured,
+        decision,
+        authorization,
+        "HANDLER_FAILED_BEFORE_DISPATCH",
+        startedAt,
+      );
+    }
+    if (attempt.status === "UNKNOWN_AFTER_DISPATCH") {
+      const result: SafeExecutionResult<TResult> = {
+        outcome: "UNKNOWN_AFTER_DISPATCH",
+        executed: null,
+        reason: "PROVIDER_OUTCOME_UNKNOWN",
+        result: null,
+        authorization,
+        recovery: SafeExecutor.recoveryReference(captured, authorization),
+      };
+      // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+      await this.record({
+        eventType: "EXECUTION_OUTCOME_UNKNOWN",
+        captured,
+        decision,
+        authorization,
+        reasonCodes: [result.reason],
+        durationMs: Date.now() - startedAt,
+      });
+      // Stryker restore all
+      return result;
+    }
+    const result: SafeExecutionResult<TResult> = {
+      outcome: "COMPLETED",
+      executed: true,
+      recovered: false,
+      result: attempt.result as TResult,
+      authorization,
+    };
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    await this.record({
+      eventType: "EXECUTION_COMPLETED",
+      captured,
+      decision,
+      authorization,
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    return result;
+  }
+
+  public async reconcile<TResult = unknown>(
+    captured: CapturedIntent,
+    recovery: ExecutionRecoveryReference,
+  ): Promise<ExecutionReconciliationResult<TResult>> {
+    const startedAt = Date.now();
+    if (
+      recovery.version !== "agent-safe.recovery/1" ||
+      recovery.intentHash !== captured.intentHash ||
+      recovery.idempotencyKey !== captured.intent.idempotencyKey ||
+      !this.intentConforms(captured)
+    ) {
+      return await this.block(captured, undefined, "RECOVERY_BINDING_MISMATCH", startedAt);
+    }
+
+    const reconciliation = await this.registry.reconcile(captured, recovery.idempotencyKey);
+    const authorization = SafeExecutor.authorizationFrom(recovery);
+    if (reconciliation.status === "COMPLETED") {
+      const result: ExecutionReconciliationResult<TResult> = {
+        outcome: "COMPLETED",
+        executed: true,
+        recovered: true,
+        result: reconciliation.result as TResult,
+        authorization,
+      };
+      // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+      await this.record({
+        eventType: "RECONCILIATION_COMPLETED",
+        captured,
+        authorization,
+        durationMs: Date.now() - startedAt,
+      });
+      // Stryker restore all
+      return result;
+    }
+    if (reconciliation.status === "NOT_EXECUTED") {
+      const result: ExecutionReconciliationResult<TResult> = {
+        outcome: "DEFINITELY_NOT_EXECUTED",
+        executed: false,
+        recovered: true,
+        reason: "PROVIDER_CONFIRMED_NOT_EXECUTED",
+        result: null,
+        authorization,
+      };
+      // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+      await this.record({
+        eventType: "RECONCILIATION_NOT_EXECUTED",
+        captured,
+        authorization,
+        reasonCodes: [result.reason],
+        durationMs: Date.now() - startedAt,
+      });
+      // Stryker restore all
+      return result;
+    }
+    const result: ExecutionReconciliationResult<TResult> = {
+      outcome: "UNKNOWN_AFTER_DISPATCH",
+      executed: null,
+      reason: "PROVIDER_OUTCOME_UNKNOWN",
+      result: null,
+      authorization,
+      recovery,
+    };
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    await this.record({
+      eventType: "RECONCILIATION_UNKNOWN",
+      captured,
+      authorization,
+      reasonCodes: [result.reason],
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    return result;
   }
 
   private intentConforms(captured: CapturedIntent): boolean {
@@ -96,7 +316,75 @@ export class SafeExecutor {
     );
   }
 
-  private static blocked(reason: ExecutionBlockReason): SafeExecutionResult<never> {
-    return { executed: false, reason, result: null, authorization: null };
+  private async block(
+    captured: CapturedIntent,
+    decision: GateDecision | undefined,
+    reason: ExecutionBlockReason,
+    startedAt: number,
+  ): Promise<ExecutionBlockedResult> {
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    await this.record({
+      eventType: "EXECUTION_BLOCKED",
+      captured,
+      ...(decision === undefined ? {} : { decision }),
+      reasonCodes: [reason],
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    return { outcome: "BLOCKED", executed: false, reason, result: null, authorization: null };
+  }
+
+  private async failedBeforeDispatch(
+    captured: CapturedIntent,
+    decision: GateDecision,
+    authorization: VerifiedAuthorization,
+    reason: ExecutionPreDispatchFailureReason,
+    startedAt: number,
+  ): Promise<Extract<SafeExecutionResult<never>, { outcome: "FAILED_BEFORE_DISPATCH" }>> {
+    // Stryker disable all: Audit payload mapping is covered by lifecycle event assertions.
+    await this.record({
+      eventType: "EXECUTION_FAILED_BEFORE_DISPATCH",
+      captured,
+      decision,
+      authorization,
+      reasonCodes: [reason],
+      durationMs: Date.now() - startedAt,
+    });
+    // Stryker restore all
+    return {
+      outcome: "FAILED_BEFORE_DISPATCH",
+      executed: false,
+      reason,
+      result: null,
+      authorization,
+    };
+  }
+
+  private async record(
+    input: Parameters<AuditRecorder["record"]>[0] & { readonly eventType: AuditEventType },
+  ): Promise<boolean> {
+    // Stryker disable next-line BooleanLiteral: The value is irrelevant when no audit policy exists.
+    return this.audit === undefined ? true : await this.audit.record(input);
+  }
+
+  private static recoveryReference(
+    captured: CapturedIntent,
+    authorization: VerifiedAuthorization,
+  ): ExecutionRecoveryReference {
+    return Object.freeze({
+      version: "agent-safe.recovery/1",
+      ...authorization,
+      idempotencyKey: captured.intent.idempotencyKey,
+    });
+  }
+
+  private static authorizationFrom(recovery: ExecutionRecoveryReference): VerifiedAuthorization {
+    return Object.freeze({
+      decisionId: recovery.decisionId,
+      dossierId: recovery.dossierId,
+      grantId: recovery.grantId,
+      intentHash: recovery.intentHash,
+      expiresAt: recovery.expiresAt,
+    });
   }
 }

--- a/packages/pipeline/src/intent/IntentCapture.ts
+++ b/packages/pipeline/src/intent/IntentCapture.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import type { AuditRecorder } from "../audit/AuditRecorder.js";
 import {
   AgentProposalSchema,
   ExecutionIntentSchema,
@@ -10,6 +11,7 @@ import {
 import { CanonicalIntentHasher } from "./CanonicalIntentHasher.js";
 
 export interface IntentCaptureOptions {
+  readonly audit?: AuditRecorder;
   readonly hasher?: CanonicalIntentHasher;
   readonly clock?: () => Date;
   readonly createId?: () => string;
@@ -21,12 +23,14 @@ export class IntentCapture {
   private readonly clock: () => Date;
   private readonly createId: () => string;
   private readonly ttlSeconds: number;
+  private readonly audit: AuditRecorder | undefined;
 
   public constructor(options?: IntentCaptureOptions) {
     this.hasher = options?.hasher ?? new CanonicalIntentHasher();
     this.clock = options?.clock ?? (() => new Date());
     this.createId = options?.createId ?? randomUUID;
     this.ttlSeconds = Math.min(Math.max(options?.ttlSeconds ?? 60, 1), 300);
+    this.audit = options?.audit;
   }
 
   public capture(proposalInput: AgentProposal, trustedInput: TrustedIntentContext): CapturedIntent {
@@ -52,5 +56,15 @@ export class IntentCapture {
       idempotencyKey: trusted.idempotencyKey,
     });
     return this.hasher.capture(intent);
+  }
+
+  /** Captures an intent and waits for the optional bounded audit sink once. */
+  public async captureAndAudit(
+    proposalInput: AgentProposal,
+    trustedInput: TrustedIntentContext,
+  ): Promise<CapturedIntent> {
+    const captured = this.capture(proposalInput, trustedInput);
+    await this.audit?.record({ eventType: "INTENT_CAPTURED", captured });
+    return captured;
   }
 }

--- a/packages/pipeline/test/approval/PresenceApprovalCoordinator.test.ts
+++ b/packages/pipeline/test/approval/PresenceApprovalCoordinator.test.ts
@@ -3,6 +3,7 @@ import {
   PresenceApprovalCoordinator,
   type PresenceApprovalClient,
 } from "../../src/approval/PresenceApprovalCoordinator.js";
+import { AuditRecorder, type AuditEventV1 } from "../../src/audit/AuditRecorder.js";
 import type { DecisionAuthority } from "../../src/decision/DecisionAuthority.js";
 import { IntentCapture } from "../../src/intent/IntentCapture.js";
 
@@ -25,6 +26,59 @@ function captured(clock?: () => number, ttlSeconds = 60) {
 }
 
 describe("PresenceApprovalCoordinator", () => {
+  it("records escalation and receipt resolution as non-authoritative evidence", async () => {
+    const intent = captured();
+    const events: AuditEventV1[] = [];
+    const audit = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const authority: DecisionAuthority = {
+      evaluate: async () => ({
+        verdict: "BLOCK",
+        decisionId: "decision-after-presence",
+        dossierId: "dossier-after-presence",
+        intentHash: intent.intentHash,
+        reasonCodes: ["POLICY_BLOCK"],
+        authorization: null,
+        failClosed: false,
+      }),
+    };
+    const coordinator = new PresenceApprovalCoordinator(
+      {
+        gate: async () => ({
+          verdict: "HUMAN_REQUIRED",
+          request_id: "synthetic-presence-request-1",
+        }),
+        outcome: async () => ({
+          verdict: "PROCEED",
+          request_id: "synthetic-presence-request-1",
+          receipt_dossier_id: "synthetic-presence-dossier-1",
+        }),
+      },
+      authority,
+      "Acme",
+      "synthetic-approver-1",
+      { audit },
+    );
+
+    await coordinator.request(intent);
+    await coordinator.resolveAndReauthorize(intent, {
+      verdict: "PROCEED",
+      request_id: "synthetic-presence-request-1",
+      receipt_dossier_id: "synthetic-presence-dossier-1",
+    });
+
+    expect(events.map(({ eventType, authority }) => ({ eventType, authority }))).toEqual([
+      { eventType: "PRESENCE_ESCALATED", authority: "NON_AUTHORITATIVE" },
+      { eventType: "PRESENCE_RESOLVED", authority: "NON_AUTHORITATIVE" },
+    ]);
+    expect(events[1]?.correlation.dossierId).toBe("synthetic-presence-dossier-1");
+  });
+
   it("polls pending outcomes and requires Decionis re-authorization of the terminal receipt", async () => {
     let now = FIXED_TIME;
     const intent = captured(() => now);

--- a/packages/pipeline/test/audit/AuditRecorder.test.ts
+++ b/packages/pipeline/test/audit/AuditRecorder.test.ts
@@ -1,0 +1,396 @@
+import { describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+import {
+  AuditPolicyRevisionVerifier,
+  AuditRecorder,
+  type AuditEventV1,
+} from "../../src/audit/AuditRecorder.js";
+import type { GateDecision } from "../../src/decision/DecisionAuthority.js";
+import { ActionRegistry } from "../../src/execution/ActionRegistry.js";
+import { SafeExecutor } from "../../src/execution/SafeExecutor.js";
+import { IntentCapture } from "../../src/intent/IntentCapture.js";
+
+const fixedDate = new Date("2026-09-07T10:00:00.000Z");
+
+function captured() {
+  return new IntentCapture({
+    clock: () => fixedDate,
+    createId: () => "00000000-0000-4000-8000-000000000001",
+  }).capture(
+    {
+      action: "refund_order",
+      target: "shopify:order:1",
+      parameters: { amount: 10, secret: "must-not-appear" },
+    },
+    {
+      tenantId: "00000000-0000-4000-8000-000000000002",
+      actor: { id: "synthetic-audit-agent", type: "AI_AGENT" },
+      downstreamTarget: { system: "shopify", operation: "refund" },
+      correlationId: "correlation-1",
+      idempotencyKey: "refund-audit-1",
+      context: { credential: "must-not-appear" },
+    },
+  );
+}
+
+function decision(intentHash: string): GateDecision {
+  return {
+    verdict: "ALLOW",
+    decisionId: "decision-1",
+    dossierId: "dossier-1",
+    intentHash,
+    reasonCodes: ["POLICY_ALLOW"],
+    authorization: { token: "must-not-appear", expiresAt: "2026-09-07T10:00:30.000Z" },
+    failClosed: false,
+  };
+}
+
+describe("AuditRecorder", () => {
+  it("emits an immutable policy-pinned event without raw intent or authorization data", async () => {
+    const events: AuditEventV1[] = [];
+    const policy = {
+      policyId: "refund-policy",
+      revisionId: "revision-17",
+      version: "2026.09",
+      digest: `sha256:${"1".repeat(64)}` as const,
+    };
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+      clock: () => fixedDate,
+      createId: () => "audit-event-1",
+    });
+    const intent = captured();
+
+    await expect(
+      recorder.record({
+        eventType: "AUTHORITY_DECISION",
+        captured: intent,
+        decision: decision(intent.intentHash),
+        evaluation: { policy },
+      }),
+    ).resolves.toBe(true);
+    policy.revisionId = "revision-18";
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      schemaVersion: "agent-safe.audit/1",
+      authority: "AUTHORITATIVE",
+      evaluation: {
+        evaluationId: "decision-1",
+        materialInputDigest: intent.intentHash,
+        policy: { revisionId: "revision-17" },
+        evidenceReference: "dossier-1",
+      },
+    });
+    expect(Object.isFrozen(events[0])).toBe(true);
+    expect(Object.isFrozen(events[0]?.evaluation?.policy)).toBe(true);
+    const serialized = JSON.stringify(events[0]);
+    expect(serialized).not.toContain("must-not-appear");
+    expect(serialized).not.toContain("parameters");
+    expect(serialized).not.toContain("shopify:order:1");
+  });
+
+  it("requires immutable policy revision identities", async () => {
+    const sink = { write: vi.fn() };
+    const recorder = new AuditRecorder({ sink });
+    const intent = captured();
+
+    await expect(
+      recorder.record({
+        eventType: "AUTHORITY_DECISION",
+        captured: intent,
+        decision: decision(intent.intentHash),
+        evaluation: {
+          policy: {
+            policyId: "refund-policy",
+            revisionId: "latest",
+            digest: `sha256:${"1".repeat(64)}`,
+          },
+        },
+      }),
+    ).resolves.toBe(false);
+    expect(sink.write).not.toHaveBeenCalled();
+  });
+
+  it("detects missing or mutated retained policy evidence and resolves replay by pinned revision", async () => {
+    const events: AuditEventV1[] = [];
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const intent = captured();
+    const firstPolicy = {
+      policyId: "refund-policy",
+      revisionId: "revision-17",
+      digest: `sha256:${"1".repeat(64)}` as const,
+    };
+    const hotfixPolicy = {
+      policyId: "refund-policy",
+      revisionId: "revision-18",
+      digest: `sha256:${"2".repeat(64)}` as const,
+    };
+    await recorder.record({
+      eventType: "AUTHORITY_DECISION",
+      captured: intent,
+      decision: decision(intent.intentHash),
+      evaluation: { policy: firstPolicy },
+    });
+    await recorder.record({
+      eventType: "AUTHORITY_DECISION",
+      captured: intent,
+      decision: { ...decision(intent.intentHash), decisionId: "decision-2" },
+      evaluation: { policy: hotfixPolicy },
+    });
+
+    expect(events[0]?.evaluation?.policy).not.toEqual(events[1]?.evaluation?.policy);
+    expect(Reflect.set(events[0]?.evaluation?.policy ?? {}, "digest", hotfixPolicy.digest)).toBe(
+      false,
+    );
+
+    const resolve = vi.fn(async (policyId: string, revisionId: string) => ({
+      policyId,
+      revisionId,
+      digest: firstPolicy.digest,
+      artifactReference: "archive-version-17",
+    }));
+    const verifier = new AuditPolicyRevisionVerifier({ resolve });
+    await expect(verifier.verify(events[0]!)).resolves.toMatchObject({
+      status: "VERIFIED",
+      artifact: { revisionId: "revision-17" },
+    });
+    expect(resolve).toHaveBeenCalledWith("refund-policy", "revision-17");
+
+    await expect(
+      new AuditPolicyRevisionVerifier({ resolve: async () => null }).verify(events[0]!),
+    ).resolves.toEqual({ status: "MISSING", artifact: null });
+    await expect(
+      new AuditPolicyRevisionVerifier({
+        resolve: async () => ({
+          ...firstPolicy,
+          digest: hotfixPolicy.digest,
+          artifactReference: "mutated-archive",
+        }),
+      }).verify(events[0]!),
+    ).resolves.toEqual({ status: "DIGEST_MISMATCH", artifact: null });
+  });
+
+  it("allowlists, redacts, and bounds consumer metadata", async () => {
+    const events: AuditEventV1[] = [];
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+      metadataAllowlist: ["region", "note", "token"],
+      redactMetadata: (key, value) => (key === "note" ? "[redacted]" : value),
+    });
+    const intent = captured();
+
+    await expect(
+      recorder.record({
+        eventType: "INTENT_CAPTURED",
+        captured: intent,
+        metadata: {
+          region: "eu-north-1",
+          note: "sensitive support note",
+          token: "forbidden-even-when-allowlisted",
+          ignored: "not allowlisted",
+        },
+      }),
+    ).resolves.toBe(true);
+    expect(events[0]?.metadata).toEqual({ region: "eu-north-1", note: "[redacted]" });
+
+    await expect(
+      recorder.record({
+        eventType: "INTENT_CAPTURED",
+        captured: intent,
+        metadata: { region: "x".repeat(501) },
+      }),
+    ).resolves.toBe(false);
+    expect(events).toHaveLength(1);
+  });
+
+  it("bounds sink timeouts and exceptions without retrying", async () => {
+    const stalled = vi.fn(async () => await new Promise<never>(() => undefined));
+    const timeoutRecorder = new AuditRecorder({ sink: { write: stalled }, timeoutMs: 1 });
+    await expect(
+      timeoutRecorder.record({ eventType: "INTENT_CAPTURED", captured: captured() }),
+    ).resolves.toBe(false);
+    expect(stalled).toHaveBeenCalledTimes(1);
+
+    const rejected = vi.fn(() => {
+      throw new Error("sink secret");
+    });
+    const rejectionRecorder = new AuditRecorder({ sink: { write: rejected } });
+    await expect(
+      rejectionRecorder.record({ eventType: "INTENT_CAPTURED", captured: captured() }),
+    ).resolves.toBe(false);
+    expect(rejected).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects malformed bounded fields and metadata before calling the sink", async () => {
+    expect(
+      () =>
+        new AuditRecorder({
+          sink: { write: vi.fn() },
+          metadataAllowlist: Array.from({ length: 51 }, (_, index) => `field-${index}`),
+        }),
+    ).toThrow("AUDIT_METADATA_ALLOWLIST_TOO_LARGE");
+
+    const write = vi.fn();
+    const recorder = new AuditRecorder({
+      sink: { write },
+      metadataAllowlist: ["value"],
+    });
+    const intent = captured();
+    const tooDeep = { child: { child: { child: { child: { child: "x" } } } } };
+    const cases = [
+      { durationMs: -1 },
+      { reasonCodes: Array.from({ length: 51 }, () => "REASON") },
+      { authority: "INVALID" },
+      { metadata: { value: Number.NaN } },
+      { metadata: { value: Array.from({ length: 21 }, () => 1) } },
+      { metadata: { value: tooDeep } },
+      { metadata: { value: new Date() } },
+    ];
+    for (const candidate of cases) {
+      await expect(
+        recorder.record({
+          eventType: "INTENT_CAPTURED",
+          captured: intent,
+          ...(candidate as unknown as {
+            durationMs?: number;
+            reasonCodes?: string[];
+            authority?: "AUTHORITATIVE";
+            metadata?: Record<string, never>;
+          }),
+        }),
+      ).resolves.toBe(false);
+    }
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("omits metadata when the redaction hook returns undefined", async () => {
+    const events: AuditEventV1[] = [];
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+      metadataAllowlist: ["region"],
+      redactMetadata: () => undefined,
+    });
+
+    await recorder.record({
+      eventType: "INTENT_CAPTURED",
+      captured: captured(),
+      metadata: { region: "eu-north-1" },
+    });
+    expect(events[0]?.metadata).toEqual({});
+  });
+
+  it("reports every retained-policy resolution failure without falling back to latest", async () => {
+    const events: AuditEventV1[] = [];
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const intent = captured();
+    await recorder.record({ eventType: "INTENT_CAPTURED", captured: intent });
+    await recorder.record({
+      eventType: "AUTHORITY_DECISION",
+      captured: intent,
+      decision: decision(intent.intentHash),
+      evaluation: {
+        policy: {
+          policyId: "refund-policy",
+          revisionId: "revision-17",
+          digest: `sha256:${"1".repeat(64)}`,
+        },
+      },
+    });
+
+    await expect(
+      new AuditPolicyRevisionVerifier({ resolve: async () => null }).verify(events[0]!),
+    ).resolves.toEqual({ status: "NOT_REFERENCED", artifact: null });
+    await expect(
+      new AuditPolicyRevisionVerifier({
+        resolve: async () => ({
+          policyId: "refund-policy",
+          revisionId: "revision-18",
+          digest: `sha256:${"1".repeat(64)}`,
+          artifactReference: "archive-version-18",
+        }),
+      }).verify(events[1]!),
+    ).resolves.toEqual({ status: "IDENTITY_MISMATCH", artifact: null });
+    await expect(
+      new AuditPolicyRevisionVerifier({
+        resolve: async () => {
+          throw new Error("archive unavailable");
+        },
+      }).verify(events[1]!),
+    ).resolves.toEqual({ status: "UNAVAILABLE", artifact: null });
+    await expect(
+      new AuditPolicyRevisionVerifier({
+        resolve: async () => ({
+          policyId: "refund-policy",
+          revisionId: "revision-17",
+          digest: `sha256:${"1".repeat(64)}`,
+          artifactReference: "",
+        }),
+      }).verify(events[1]!),
+    ).resolves.toEqual({ status: "UNAVAILABLE", artifact: null });
+  });
+
+  it("keeps a serialized shadow ALLOW observational and unusable as execution authority", async () => {
+    const events: AuditEventV1[] = [];
+    const recorder = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const intent = captured();
+    await recorder.record({
+      eventType: "AUTHORITY_DECISION",
+      authority: "OBSERVATIONAL",
+      captured: intent,
+      decision: decision(intent.intentHash),
+    });
+    const persisted = JSON.parse(JSON.stringify(events[0])) as GateDecision;
+    const execute = vi.fn();
+    const registry = new ActionRegistry()
+      .register("refund_order", {
+        parametersSchema: z.object({
+          amount: z.number(),
+          secret: z.string(),
+        }),
+        execute,
+      })
+      .seal();
+    const verifyAndConsume = vi.fn();
+
+    expect(events[0]?.authority).toBe("OBSERVATIONAL");
+    await expect(
+      new SafeExecutor(registry, { verifyAndConsume }).run(intent, persisted),
+    ).resolves.toMatchObject({
+      outcome: "BLOCKED",
+      reason: "INTENT_BINDING_MISMATCH",
+    });
+    expect(verifyAndConsume).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/pipeline/test/execution/ActionRegistry.test.ts
+++ b/packages/pipeline/test/execution/ActionRegistry.test.ts
@@ -79,4 +79,53 @@ describe("ActionRegistry", () => {
       "ACTION_PARAMETERS_INVALID",
     );
   });
+
+  it("allows only one provider dispatch and exposes the trusted idempotency key", async () => {
+    const operation = vi.fn(async (idempotencyKey: string) => idempotencyKey);
+    const registry = new ActionRegistry()
+      .register("refund_order", {
+        parametersSchema: z.object({ amount: z.number() }),
+        execute: async ({ dispatch }) => {
+          const result = await dispatch.run(operation);
+          await expect(dispatch.run(operation)).rejects.toThrow(
+            "PROVIDER_DISPATCH_ALREADY_STARTED",
+          );
+          return result;
+        },
+      })
+      .seal();
+    const intent = captured();
+
+    await expect(registry.executeTracked(intent, authorization)).resolves.toMatchObject({
+      status: "COMPLETED",
+      result: intent.intent.idempotencyKey,
+    });
+    expect(operation).toHaveBeenCalledTimes(1);
+    expect(operation).toHaveBeenCalledWith(intent.intent.idempotencyKey);
+  });
+
+  it("converts malformed or rejected reconciliation into UNKNOWN", async () => {
+    const reconcile = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "COMPLETED" })
+      .mockRejectedValueOnce(new Error("private provider response"));
+    const registry = new ActionRegistry()
+      .register("refund_order", {
+        parametersSchema: z.object({ amount: z.number() }),
+        execute: vi.fn(),
+        reconcile,
+      })
+      .seal();
+    const intent = captured();
+
+    await expect(registry.reconcile(intent, intent.intent.idempotencyKey)).resolves.toEqual({
+      status: "UNKNOWN",
+    });
+    await expect(registry.reconcile(intent, intent.intent.idempotencyKey)).resolves.toEqual({
+      status: "UNKNOWN",
+    });
+    await expect(registry.reconcile(intent, "different-key")).rejects.toThrow(
+      "RECONCILIATION_BINDING_MISMATCH",
+    );
+  });
 });

--- a/packages/pipeline/test/execution/SafeExecutor.test.ts
+++ b/packages/pipeline/test/execution/SafeExecutor.test.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
 import { describe, expect, it, vi } from "vitest";
+import { AuditRecorder, type AuditEventV1 } from "../../src/audit/AuditRecorder.js";
 import type { GateDecision } from "../../src/decision/DecisionAuthority.js";
 import { createFixtureAuthorityPair } from "../../src/decision/FixtureDecisionAuthority.js";
-import { ActionRegistry } from "../../src/execution/ActionRegistry.js";
+import { ActionRegistry, type ActionExecutionContext } from "../../src/execution/ActionRegistry.js";
 import type { VerifiedAuthorization } from "../../src/execution/AuthorizationVerifier.js";
 import { SafeExecutor } from "../../src/execution/SafeExecutor.js";
 import { IntentCapture } from "../../src/intent/IntentCapture.js";
@@ -25,9 +26,16 @@ function captured(amount = 350) {
 }
 
 function setup(verdict: "ALLOW" | "BLOCK" | "ESCALATE" = "ALLOW") {
-  const execute = vi.fn(({ parameters }: { parameters: { amount: number; currency: string } }) => ({
-    refundId: `refund-${parameters.amount}`,
-  }));
+  const execute = vi.fn(
+    async ({
+      parameters,
+      dispatch,
+    }: ActionExecutionContext<{ amount: number; currency: string }>) =>
+      await dispatch.run(async (idempotencyKey) => ({
+        refundId: `refund-${parameters.amount}`,
+        idempotencyKey,
+      })),
+  );
   const registry = new ActionRegistry()
     .register("refund_order", {
       parametersSchema: z.object({ amount: z.number().positive(), currency: z.string().length(3) }),
@@ -71,6 +79,7 @@ describe("SafeExecutor", () => {
     const result = await executor.run<{ refundId: string }>(intent, decision);
 
     expect(result.executed).toBe(true);
+    expect(result).toMatchObject({ outcome: "COMPLETED", recovered: false });
     expect(execute).toHaveBeenCalledTimes(1);
     if (result.executed) {
       expect(result.result.refundId).toBe("refund-350");
@@ -340,7 +349,7 @@ describe("SafeExecutor", () => {
     }
   });
 
-  it("does not expose raw handler failures", async () => {
+  it("classifies and redacts a handler failure before provider dispatch", async () => {
     const registry = new ActionRegistry()
       .register("refund_order", {
         parametersSchema: z.object({ amount: z.number(), currency: z.string() }),
@@ -356,7 +365,336 @@ describe("SafeExecutor", () => {
 
     await expect(
       new SafeExecutor(registry, pair.verifier).run(intent, await pair.authority.evaluate(intent)),
-    ).rejects.toThrow("ACTION_EXECUTION_FAILED");
+    ).resolves.toEqual(
+      expect.objectContaining({
+        outcome: "FAILED_BEFORE_DISPATCH",
+        executed: false,
+        reason: "HANDLER_FAILED_BEFORE_DISPATCH",
+        result: null,
+      }),
+    );
+  });
+
+  it.each(["provider timeout", "connection reset"])(
+    "returns an unknown outcome after %s and never invokes the handler twice for one grant",
+    async (failure) => {
+      const execute = vi.fn(
+        async ({ dispatch }: ActionExecutionContext<{ amount: number; currency: string }>) =>
+          await dispatch.run(async () => {
+            throw new Error(failure);
+          }),
+      );
+      const registry = new ActionRegistry()
+        .register("refund_order", {
+          parametersSchema: z.object({ amount: z.number(), currency: z.string() }),
+          execute,
+        })
+        .seal();
+      const pair = createFixtureAuthorityPair(() => "ALLOW", {
+        unsafeAllowDevelopmentFixture: true,
+      });
+      const intent = captured();
+      const decision = await pair.authority.evaluate(intent);
+      const executor = new SafeExecutor(registry, pair.verifier);
+
+      const first = await executor.run(intent, decision);
+      expect(first).toMatchObject({
+        outcome: "UNKNOWN_AFTER_DISPATCH",
+        executed: null,
+        reason: "PROVIDER_OUTCOME_UNKNOWN",
+        recovery: {
+          version: "agent-safe.recovery/1",
+          intentHash: intent.intentHash,
+          idempotencyKey: intent.intent.idempotencyKey,
+        },
+      });
+      await expect(executor.run(intent, decision)).resolves.toMatchObject({
+        outcome: "BLOCKED",
+        reason: "AUTHORIZATION_INVALID",
+      });
+      expect(execute).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("reconciles concurrent recovery attempts once and returns the provider's original result", async () => {
+    let release: (() => void) | undefined;
+    const reconcile = vi.fn(
+      async () =>
+        await new Promise<{ status: "COMPLETED"; result: { refundId: string } }>((resolve) => {
+          release = () => resolve({ status: "COMPLETED", result: { refundId: "provider-123" } });
+        }),
+    );
+    const registry = new ActionRegistry()
+      .register("refund_order", {
+        parametersSchema: z.object({ amount: z.number(), currency: z.string() }),
+        execute: async ({ dispatch }) =>
+          await dispatch.run(async () => {
+            throw new Error("response lost");
+          }),
+        reconcile,
+      })
+      .seal();
+    const pair = createFixtureAuthorityPair(() => "ALLOW", {
+      unsafeAllowDevelopmentFixture: true,
+    });
+    const intent = captured();
+    const executor = new SafeExecutor(registry, pair.verifier);
+    const attempt = await executor.run(intent, await pair.authority.evaluate(intent));
+    if (attempt.outcome !== "UNKNOWN_AFTER_DISPATCH") throw new Error("TEST_EXPECTED_UNKNOWN");
+
+    const first = executor.reconcile<{ refundId: string }>(intent, attempt.recovery);
+    const second = executor.reconcile<{ refundId: string }>(intent, attempt.recovery);
+    await vi.waitFor(() => expect(reconcile).toHaveBeenCalledTimes(1));
+    release?.();
+
+    await expect(first).resolves.toMatchObject({
+      outcome: "COMPLETED",
+      executed: true,
+      recovered: true,
+      result: { refundId: "provider-123" },
+      authorization: {
+        decisionId: attempt.recovery.decisionId,
+        dossierId: attempt.recovery.dossierId,
+        grantId: attempt.recovery.grantId,
+        intentHash: attempt.recovery.intentHash,
+        expiresAt: attempt.recovery.expiresAt,
+      },
+    });
+    await expect(second).resolves.toMatchObject({
+      outcome: "COMPLETED",
+      executed: true,
+      recovered: true,
+    });
+    expect(reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({ idempotencyKey: intent.intent.idempotencyKey }),
+    );
+  });
+
+  it("preserves unknown recovery state and accepts a provider proof that no action occurred", async () => {
+    const reconciliation = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("lookup unavailable"))
+      .mockResolvedValueOnce({ status: "NOT_EXECUTED" as const });
+    const registry = new ActionRegistry()
+      .register("refund_order", {
+        parametersSchema: z.object({ amount: z.number(), currency: z.string() }),
+        execute: async ({ dispatch }) =>
+          await dispatch.run(async () => {
+            throw new Error("response lost");
+          }),
+        reconcile: reconciliation,
+      })
+      .seal();
+    const pair = createFixtureAuthorityPair(() => "ALLOW", {
+      unsafeAllowDevelopmentFixture: true,
+    });
+    const intent = captured();
+    const executor = new SafeExecutor(registry, pair.verifier);
+    const attempt = await executor.run(intent, await pair.authority.evaluate(intent));
+    if (attempt.outcome !== "UNKNOWN_AFTER_DISPATCH") throw new Error("TEST_EXPECTED_UNKNOWN");
+
+    await expect(executor.reconcile(intent, attempt.recovery)).resolves.toMatchObject({
+      outcome: "UNKNOWN_AFTER_DISPATCH",
+      executed: null,
+      reason: "PROVIDER_OUTCOME_UNKNOWN",
+      recovery: attempt.recovery,
+    });
+    await expect(executor.reconcile(intent, attempt.recovery)).resolves.toMatchObject({
+      outcome: "DEFINITELY_NOT_EXECUTED",
+      executed: false,
+      recovered: true,
+      reason: "PROVIDER_CONFIRMED_NOT_EXECUTED",
+    });
+  });
+
+  it("rejects every altered recovery binding independently", async () => {
+    const { pair, executor } = setup();
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+    const recovery = {
+      version: "agent-safe.recovery/1" as const,
+      ...authorizationFor(decision, intent.intentHash),
+      idempotencyKey: intent.intent.idempotencyKey,
+    };
+    const malformedIntent = { ...intent, canonicalIntent: "{}" };
+    const cases = [
+      { captured: intent, recovery: { ...recovery, version: "agent-safe.recovery/2" } },
+      {
+        captured: intent,
+        recovery: { ...recovery, intentHash: `sha256:${"0".repeat(64)}` },
+      },
+      { captured: intent, recovery: { ...recovery, idempotencyKey: "other-operation" } },
+      { captured: malformedIntent, recovery },
+    ];
+
+    for (const candidate of cases) {
+      await expect(
+        executor.reconcile(candidate.captured, candidate.recovery as never),
+      ).resolves.toMatchObject({
+        outcome: "BLOCKED",
+        reason: "RECOVERY_BINDING_MISMATCH",
+      });
+    }
+  });
+
+  it("emits the ordered, redacted authorization and execution lifecycle", async () => {
+    const { execute, pair, registry } = setup();
+    const events: AuditEventV1[] = [];
+    const audit = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+
+    await expect(
+      new SafeExecutor(registry, pair.verifier, audit).run(intent, decision),
+    ).resolves.toMatchObject({
+      outcome: "COMPLETED",
+    });
+
+    expect(events.map((event) => event.eventType)).toEqual([
+      "INTENT_CAPTURED",
+      "AUTHORITY_DECISION",
+      "GRANT_CONSUMED",
+      "EXECUTION_STARTED",
+      "EXECUTION_COMPLETED",
+    ]);
+    expect(events[2]?.correlation).toMatchObject({
+      intentId: intent.intent.intentId,
+      intentHash: intent.intentHash,
+      decisionId: decision.decisionId,
+      dossierId: decision.dossierId,
+    });
+    expect(JSON.stringify(events)).not.toContain("fixture-token");
+    expect(JSON.stringify(events)).not.toContain("refundId");
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails before provider dispatch when required audit delivery fails after grant consumption", async () => {
+    const { execute, pair, registry } = setup();
+    const write = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("audit unavailable"))
+      .mockResolvedValue(undefined);
+    const audit = new AuditRecorder({
+      sink: { write },
+      failurePolicy: "REQUIRE_BEFORE_EXECUTION",
+    });
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+    const verifyAndConsume = vi.fn(pair.verifier.verifyAndConsume.bind(pair.verifier));
+
+    await expect(
+      new SafeExecutor(registry, { verifyAndConsume }, audit).run(intent, decision),
+    ).resolves.toMatchObject({
+      outcome: "FAILED_BEFORE_DISPATCH",
+      executed: false,
+      reason: "AUDIT_UNAVAILABLE",
+    });
+    expect(verifyAndConsume).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("fails before provider dispatch when required execution-start evidence is unavailable", async () => {
+    const { execute, pair, registry } = setup();
+    const write = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("audit unavailable"))
+      .mockResolvedValue(undefined);
+    const audit = new AuditRecorder({
+      sink: { write },
+      failurePolicy: "REQUIRE_BEFORE_EXECUTION",
+    });
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+    const verifyAndConsume = vi.fn(pair.verifier.verifyAndConsume.bind(pair.verifier));
+
+    await expect(
+      new SafeExecutor(registry, { verifyAndConsume }, audit).run(intent, decision),
+    ).resolves.toMatchObject({
+      outcome: "FAILED_BEFORE_DISPATCH",
+      executed: false,
+      reason: "AUDIT_UNAVAILABLE",
+    });
+    expect(verifyAndConsume).toHaveBeenCalledTimes(1);
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("does not consume a grant when required initial audit evidence is unavailable", async () => {
+    const { execute, pair, registry } = setup();
+    const audit = new AuditRecorder({
+      sink: {
+        write: async () => {
+          throw new Error("audit unavailable");
+        },
+      },
+      failurePolicy: "REQUIRE_BEFORE_EXECUTION",
+    });
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+    const verifyAndConsume = vi.fn(pair.verifier.verifyAndConsume.bind(pair.verifier));
+
+    await expect(
+      new SafeExecutor(registry, { verifyAndConsume }, audit).run(intent, decision),
+    ).resolves.toMatchObject({
+      outcome: "BLOCKED",
+      executed: false,
+      reason: "AUDIT_UNAVAILABLE",
+    });
+    expect(verifyAndConsume).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("requires both initial audit events under the strict delivery policy", async () => {
+    const { execute, pair, registry } = setup();
+    const write = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("decision audit unavailable"))
+      .mockResolvedValue(undefined);
+    const audit = new AuditRecorder({
+      sink: { write },
+      failurePolicy: "REQUIRE_BEFORE_EXECUTION",
+    });
+    const intent = captured();
+    const decision = await pair.authority.evaluate(intent);
+    const verifyAndConsume = vi.fn(pair.verifier.verifyAndConsume.bind(pair.verifier));
+
+    await expect(
+      new SafeExecutor(registry, { verifyAndConsume }, audit).run(intent, decision),
+    ).resolves.toMatchObject({ outcome: "BLOCKED", reason: "AUDIT_UNAVAILABLE" });
+    expect(verifyAndConsume).not.toHaveBeenCalled();
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("keeps best-effort audit failure from changing successful execution", async () => {
+    const { execute, pair, registry } = setup();
+    const audit = new AuditRecorder({
+      sink: {
+        write: async () => {
+          throw new Error("audit unavailable");
+        },
+      },
+      failurePolicy: "BEST_EFFORT",
+    });
+    const intent = captured();
+
+    await expect(
+      new SafeExecutor(registry, pair.verifier, audit).run(
+        intent,
+        await pair.authority.evaluate(intent),
+      ),
+    ).resolves.toMatchObject({ outcome: "COMPLETED", executed: true, recovered: false });
+    expect(execute).toHaveBeenCalledTimes(1);
   });
 
   it("forbids the fixture authority in production even with explicit development opt-in", () => {

--- a/packages/pipeline/test/intent/IntentCapture.test.ts
+++ b/packages/pipeline/test/intent/IntentCapture.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { AuditRecorder, type AuditEventV1 } from "../../src/audit/AuditRecorder.js";
 import { CanonicalIntentHasher } from "../../src/intent/CanonicalIntentHasher.js";
 import { IntentCapture } from "../../src/intent/IntentCapture.js";
 import type { AgentProposal, TrustedIntentContext } from "../../src/intent/ExecutionIntent.js";
@@ -29,6 +30,33 @@ function capture(proposal: AgentProposal, context = trusted()) {
 }
 
 describe("IntentCapture", () => {
+  it("can await a bounded capture audit event", async () => {
+    const events: AuditEventV1[] = [];
+    const audit = new AuditRecorder({
+      sink: {
+        write: (event) => {
+          events.push(event);
+        },
+      },
+    });
+    const intentCapture = new IntentCapture({
+      audit,
+      clock: () => fixedDate,
+      createId: () => fixedId,
+    });
+
+    const intent = await intentCapture.captureAndAudit(
+      { action: "refund_order", target: "shopify:order:58291", parameters: {} },
+      trusted(),
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventType: "INTENT_CAPTURED",
+      correlation: { intentHash: intent.intentHash },
+    });
+  });
+
   it("produces the same canonical hash regardless of object insertion order", () => {
     const first = capture({
       action: "refund_order",

--- a/tests/integration/npm-pack/consumer.mjs
+++ b/tests/integration/npm-pack/consumer.mjs
@@ -15,6 +15,8 @@ console.log(`Imported ${exports.length} exports:`, exports);
 const EXPECTED_RUNTIME = [
   "ActionRegistry",
   "AgentProposalSchema",
+  "AuditPolicyRevisionVerifier",
+  "AuditRecorder",
   "CanonicalIntentHasher",
   "DecionisGate",
   "DecionisGrantVerifier",


### PR DESCRIPTION
Summary:
- publish the roadmap, supported-version policy, and vulnerability response runbook
- add explicit completed, blocked, pre-dispatch failure, and unknown-after-dispatch outcomes with read-only reconciliation
- add bounded redacted lifecycle audit events, policy-revision evidence verification, and Presence correlation
- migrate examples to the one-shot trusted provider dispatch boundary

Verification:
- pnpm verify (all local and protected CI gates passed)
- 97 package tests passed
- coverage: 91.93% statements, 90.01% branches, 94.95% functions, 95.60% lines
- mutation assurance: 100%

Closes #46
Closes #47
Closes #63
Closes #64