### PR TITLE
ci: pin CommerceGate workflow actions by commit hash

### DIFF
--- a/.github/workflows/commerce-mcp-npm-publish.yml
+++ b/.github/workflows/commerce-mcp-npm-publish.yml
@@ -38,13 +38,13 @@ jobs:
     runs-on: ubuntu-latest
     environment: package-publish
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: pnpm/action-setup@v6
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 9.15.3
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -116,7 +116,7 @@ jobs:
       - name: Decionis Action Gate (shadow)
         if: ${{ inputs.mode == 'publish' }}
         continue-on-error: true
-        uses: decionis/govern@v1
+        uses: decionis/govern@6bc8bd3fc0dab105703fe3dc8c6c7a1d738bcf29 # v1.9.3
         with:
           api-key: ${{ secrets.DECIONIS_API_KEY }}
           org-id: ${{ secrets.DECIONIS_ORG_ID }}

--- a/.github/workflows/commerce-mcp-registry-publish.yml
+++ b/.github/workflows/commerce-mcp-registry-publish.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -176,7 +176,7 @@ jobs:
       - name: Decionis Action Gate (shadow)
         if: ${{ steps.release.outputs.already_exists != 'true' }}
         continue-on-error: true
-        uses: decionis/govern@v1
+        uses: decionis/govern@6bc8bd3fc0dab105703fe3dc8c6c7a1d738bcf29 # v1.9.3
         with:
           api-key: ${{ secrets.DECIONIS_API_KEY }}
           org-id: ${{ secrets.DECIONIS_ORG_ID }}


### PR DESCRIPTION
## Why

The two workflows imported with the CommerceGate MCP in #105 reference actions by tag. Every other workflow in this repository pins by commit hash. The OpenSSF Scorecard Pinned-Dependencies check fell from 9 to 7 at that import, which took the displayed aggregate score from 8.0 to 7.9. The Scorecard results by commit are available from `https://api.scorecard.dev/projects/github.com/decionis/agent-safe-pipeline?commit=<sha>`; the transition is between `aca79fb` and `9d2d767`.

## What

Pin the six references to the commits their tags resolve to today, with the version in a trailing comment so Dependabot keeps updating them:

| Reference | Pinned to | Version |
| --- | --- | --- |
| `actions/checkout@v7` | `3d3c42e5aac5ba805825da76410c181273ba90b1` | v7.0.1, same as `deploy.yml` |
| `pnpm/action-setup@v6` | `0977fd99725f1db4007ccb2928dbb4e90d06cc86` | v6.0.10, same as `deploy.yml` |
| `actions/setup-node@v7` | `820762786026740c76f36085b0efc47a31fe5020` | v7.0.0, same as `deploy.yml` |
| `decionis/govern@v1` | `6bc8bd3fc0dab105703fe3dc8c6c7a1d738bcf29` | v1.9.3 |

Files: `.github/workflows/commerce-mcp-npm-publish.yml` (lines 41, 43, 47, 119) and `.github/workflows/commerce-mcp-registry-publish.yml` (lines 36, 179).

## Out of scope

The unhashed `npm install` commands that Scorecard also lists in these workflows are unchanged. They match the pattern already accepted in `deploy.yml` and `test-packed-package.yml`, and npm offers no hash pinning for global installs.

## Verification

- No `uses:` reference in any workflow remains without a 40-hex hash.
- Prettier and `pnpm dependabot:check` pass; the pre-commit guardrail suite passed on commit.
- Expected effect: Pinned-Dependencies returns to 9 and the aggregate to 8.0 on the next Scorecard run after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
