### PR TITLE
commerce-mcp: carry the refundable balance and refund history on REFUND_REQUEST

### DIFF
--- a/packages/commerce-mcp/README.md
+++ b/packages/commerce-mcp/README.md
@@ -74,15 +74,15 @@ enabled_tools = [
 
 Every action includes a stable `actor`, a `platform`, and a bounded `idempotency_key`. The payload is selected by `action_type`:
 
-| Action type            | Payload                                                                                           |
-| ---------------------- | ------------------------------------------------------------------------------------------------- |
-| `ORDER_ACCEPTANCE`     | nullable `order_id`, `gross_amount`, `discount_amount`, `estimated_cost`, optional `currency`     |
-| `PRICE_CHANGE`         | `sku`, nullable `from_price`, `to_price`, optional nullable `estimated_cost`, optional `currency` |
-| `INVENTORY_MUTATION`   | `sku`, nullable `from`, `to`, optional `location_id`                                              |
-| `FULFILLMENT_ACTION`   | `order_id`, `action` (`acknowledge`, `ship`, `cancel`, or `hold`)                                 |
-| `PROMOTION_CHANGE`     | nullable `promotion_id`, `percentage_fraction`, `ends_at`, `status`, and `combines_with`          |
-| `REFUND_REQUEST`       | `order_id`, `amount`, optional `currency` and `reason_code`                                       |
-| `RETURN_AUTHORIZATION` | `order_id`, optional `rma_id` and `amount`                                                        |
+| Action type            | Payload                                                                                                |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| `ORDER_ACCEPTANCE`     | nullable `order_id`, `gross_amount`, `discount_amount`, `estimated_cost`, optional `currency`          |
+| `PRICE_CHANGE`         | `sku`, nullable `from_price`, `to_price`, optional nullable `estimated_cost`, optional `currency`      |
+| `INVENTORY_MUTATION`   | `sku`, nullable `from`, `to`, optional `location_id`                                                   |
+| `FULFILLMENT_ACTION`   | `order_id`, `action` (`acknowledge`, `ship`, `cancel`, or `hold`)                                      |
+| `PROMOTION_CHANGE`     | nullable `promotion_id`, `percentage_fraction`, `ends_at`, `status`, and `combines_with`               |
+| `REFUND_REQUEST`       | `order_id`, `amount`, optional `currency`, `reason_code`, `remaining_refundable`, `prior_refund_count` |
+| `RETURN_AUTHORIZATION` | `order_id`, optional `rma_id` and `amount`                                                             |
 
 Order acceptance and price change have native CommerceGate margin mappings. The other five action types are generic Protocol Shadow evaluations: the server validates and normalizes their shape, but the result is only as complete as the active tenant policy and the submitted facts. A verdict says whether the action clears policy, not whether the platform's connector can carry it out.
 

--- a/packages/commerce-mcp/src/CommerceGateClient.ts
+++ b/packages/commerce-mcp/src/CommerceGateClient.ts
@@ -123,6 +123,10 @@ export interface RefundRequestAction extends ActionBase {
     amount: number;
     currency?: string;
     reason_code?: string | null;
+    /** Product amount the order still has left to refund, when the agent knows it. */
+    remaining_refundable?: number;
+    /** Refunds already applied to the same order line (the double-refund signal). */
+    prior_refund_count?: number;
   };
 }
 
@@ -465,7 +469,17 @@ function evaluationFacts(action: CommerceAction): EvaluationFacts {
       };
     }
     case "REFUND_REQUEST": {
-      const refund = { refund_amount: action.payload.amount };
+      const remaining = action.payload.remaining_refundable;
+      // Starter policy v2 reads refund_amount (unattended limit),
+      // refund_exceeds_refundable (refundable balance) and prior_refund_count
+      // (repeat refund). The two derived facts exist only when the agent supplied
+      // the balance, so a rule on them cannot fire on a guess.
+      const refund = {
+        refund_amount: action.payload.amount,
+        ...(remaining === undefined
+          ? {}
+          : { refund_exceeds_refundable: action.payload.amount > remaining + 0.00001 }),
+      };
       return {
         amount: action.payload.amount,
         derived: refund,

--- a/packages/commerce-mcp/src/Tools.ts
+++ b/packages/commerce-mcp/src/Tools.ts
@@ -433,6 +433,18 @@ const refundRequestActionSchema = {
         amount: { type: "number", minimum: 0 },
         currency: currencySchema,
         reason_code: nullableIdentifierSchema,
+        remaining_refundable: {
+          type: "number",
+          minimum: 0,
+          description:
+            "Product amount the order still has left to refund. Enables the refundable-balance rule.",
+        },
+        prior_refund_count: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Refunds already applied to the same order line. Enables the repeat-refund rule.",
+        },
       },
       additionalProperties: false,
     },

--- a/packages/commerce-mcp/test/CommerceGateClient.test.ts
+++ b/packages/commerce-mcp/test/CommerceGateClient.test.ts
@@ -330,6 +330,37 @@ describe("CommerceGateClient", () => {
       },
     },
     {
+      label: "refund request with the refundable balance and refund history",
+      action: {
+        action_type: "REFUND_REQUEST",
+        actor: { type: "AGENT", id: "support-agent" },
+        platform: "walmart-marketplace",
+        idempotency_key: "order:5:refund:2",
+        payload: {
+          order_id: "5",
+          amount: 2850,
+          currency: "USD",
+          remaining_refundable: 1200,
+          prior_refund_count: 1,
+        },
+      },
+      expected: {
+        decision_type: "REFUND_REQUEST",
+        amount: 2850,
+        context: {
+          refund_amount: 2850,
+          refund_exceeds_refundable: true,
+          signals: {
+            order_id: "5",
+            refund_amount: 2850,
+            remaining_refundable: 1200,
+            refund_exceeds_refundable: true,
+            prior_refund_count: 1,
+          },
+        },
+      },
+    },
+    {
       label: "return authorization",
       action: {
         action_type: "RETURN_AUTHORIZATION",


### PR DESCRIPTION
## Summary

Companion to the Commerce dashboard's **starter policy v2** (Refund Guard): three new rules read `signals.refund_amount`, `signals.refund_exceeds_refundable` and `signals.prior_refund_count`. The `REFUND_REQUEST` preflight only sent `refund_amount`, so an agent could never trip the refundable-balance or repeat-refund rules through this MCP.

- `REFUND_REQUEST.payload` gains two optional facts: `remaining_refundable` (number ≥ 0) and `prior_refund_count` (integer ≥ 0). `additionalProperties: false` is kept; the existing "refund extra field" rejection test still passes.
- `CommerceGateClient` derives `refund_exceeds_refundable` **only when `remaining_refundable` was supplied**, so a policy rule on it cannot fire on a guess. Both facts land under `context.signals` next to the existing refund facts.
- README action table updated.

Not in this PR: a version bump. Ship it with the next `@decionis/commerce` release (0.1.4) and bump `COMMERCEGATE_NPM_VERSION` in Commerce's `MachineDiscovery.ts` in that same change, per `docs/marketplace/mcp-registries.md`.

## Test plan
- [x] `pnpm test` (vitest 84 passed + `verify:package`), `pnpm typecheck`, `pnpm lint`, prettier
- [x] new client case: `amount 2850`, `remaining_refundable 1200`, `prior_refund_count 1` → `refund_exceeds_refundable: true` in `context` and `context.signals`
- [ ] after release: `commercegate_evaluate_action` with the two new facts against an org on starter v2 returns BLOCK for an over-balance refund and HOLD for a repeat refund

🤖 Generated with [Claude Code](https://claude.com/claude-code)
